### PR TITLE
Replace older WebApiClient with new RetryHelper.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,12 @@ targetCompatibility = 1.7
 dependencies {
     compile     'org.embulk:embulk-core:0.8.15'
     provided    'org.embulk:embulk-core:0.8.15'
-    compile     'org.jboss.resteasy:resteasy-client:3.0.19.Final'
-    compile     'org.glassfish.jersey.core:jersey-client:2.25'
+    compile     'javax.ws.rs:javax.ws.rs-api:2.0.1'
 
     testCompile 'junit:junit:4.+'
     testCompile 'org.embulk:embulk-core:0.8.15:tests'
+    // RESTEasy JAX-RS implementation is required only for testing.
+    testCompile 'org.jboss.resteasy:resteasy-client:3.0.19.Final'
 }
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/org/embulk/base/restclient/ClientCreatable.java
+++ b/src/main/java/org/embulk/base/restclient/ClientCreatable.java
@@ -1,0 +1,6 @@
+package org.embulk.base.restclient;
+
+public interface ClientCreatable<T extends RestClientTaskBase>
+{
+    public javax.ws.rs.client.Client createClient(T task);
+}

--- a/src/main/java/org/embulk/base/restclient/request/AutoCloseableClient.java
+++ b/src/main/java/org/embulk/base/restclient/request/AutoCloseableClient.java
@@ -1,0 +1,28 @@
+package org.embulk.base.restclient.request;
+
+import org.embulk.base.restclient.ClientCreatable;
+import org.embulk.base.restclient.RestClientTaskBase;
+
+public class AutoCloseableClient<T extends RestClientTaskBase>
+        implements AutoCloseable
+{
+    public AutoCloseableClient(T task, ClientCreatable<T> clientCreator)
+    {
+        this.client = clientCreator.createClient(task);
+    }
+
+    public javax.ws.rs.client.Client getClient()
+    {
+        return this.client;
+    }
+
+    @Override
+    public void close()
+    {
+        if (this.client != null) {
+            this.client.close();
+        }
+    }
+
+    private final javax.ws.rs.client.Client client;
+}

--- a/src/main/java/org/embulk/base/restclient/request/SingleRequester.java
+++ b/src/main/java/org/embulk/base/restclient/request/SingleRequester.java
@@ -1,19 +1,67 @@
 package org.embulk.base.restclient.request;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
-
-public abstract class SingleRequester
+/**
+ * SingleRequester is to define a single request to the target REST service to be ready for retries.
+ *
+ * It is expected to use with {@link RetryHelper} as follows. {@code RetryHelper} is given for {@code PageLoadable#loadPage}.
+ *
+ * <pre>{@code
+ * javax.ws.rs.core.Response response = retryHelper.requestWithRetry(
+ *     new SingleRequester() {
+ *         @Override
+ *         public boolean isResponseStatusRetryable(javax.ws.rs.core.Response response)
+ *         {
+ *             return (response.getStatus() / 100) == 4;
+ *         }
+ *
+ *         @Override
+ *         public Response requestOnce(javax.ws.rs.client.Client client)
+ *         {
+ *             return client.target("https://example.com/api/resource").request().get;
+ *         }
+ *     });
+ * }</pre>
+ */
+abstract public class SingleRequester
 {
-    public abstract Response request();
+    /**
+     * Requests to the target service with the given {@code javax.ws.rs.client.Client}.
+     *
+     * The method is {@code abstract} that must be overridden.
+     */
+    abstract public javax.ws.rs.core.Response requestOnce(javax.ws.rs.client.Client client);
 
-    public boolean isNotRetryable(Exception e)
-    {
-        if (e instanceof WebApplicationException) {
-            return ((WebApplicationException) e).getResponse().getStatus() / 100 == 4;
+    /**
+     * Returns {@code true} if the given {@code Exception} from {@link RetryHelper} is to retry.
+     *
+     * This method cannot be overridden. Override {@code isResponseStatusRetryable} and {@code isExceptionRetryable}
+     * instead. {@code isResponseStatusRetryable} is called for {@code javax.ws.rs.WebApplicationException}.
+     * {@code isExceptionRetryable} is called for other exceptions.
+     */
+    public final boolean toRetry(Exception exception) {
+        // Expects |javax.ws.rs.WebApplicationException| is throws in case of HTTP error status
+        // such as implemented in |RetryHelper|.
+        if (exception instanceof javax.ws.rs.WebApplicationException) {
+            return isResponseStatusToRetry(((javax.ws.rs.WebApplicationException) exception).getResponse());
         }
         else {
-            return false;
+            return isExceptionToRetry(exception);
         }
+    }
+
+    /**
+     * Returns {@code true} if the given {@code javax.ws.rs.core.Response} is to retry.
+     *
+     * This method is {@code abstract} to be overridden, and {@code protected} to be called from {@code isRetryable}.
+     */
+    abstract protected boolean isResponseStatusToRetry(javax.ws.rs.core.Response response);
+
+    /**
+     * Returns true if the given {@code Exception} is to retry.
+     *
+     * This method available to override, and {@code protected} to be called from {@code isRetryable}.
+     */
+    protected boolean isExceptionToRetry(Exception exception) {
+        return false;
     }
 }


### PR DESCRIPTION
Note that the older |WebApiClient| has already been just renamed to |RetryHelper|.

It's purely refactorying and renaming.

1. Rename fetchWithRetry to requestWithRetry to use even for output.

2. Rename WebApiClient with RetryHelper not to be confused with JAX-RS
|Client| and the |WebApi"Client"|.

3. Rename |RetryableWebApiCall| to |SingleRequester| to make it clear
this makes a request.

4. Receive JAX-RS |Client| in implementation of |SingleRequester|
instead of calling |getClient| of |WebApiClient|.

5. Create JAX-RS |Client| out of the restclient core by refactoring
|ClientCreatable| out.