### PR TITLE
Add JacksonJsonPointerValueLocator to locate a value not on the top level.

### DIFF
--- a/src/main/java/org/embulk/base/restclient/record/JacksonJsonPointerValueLocator.java
+++ b/src/main/java/org/embulk/base/restclient/record/JacksonJsonPointerValueLocator.java
@@ -1,0 +1,27 @@
+package org.embulk.base.restclient.record;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class JacksonJsonPointerValueLocator
+        extends JacksonValueLocator
+{
+    public JacksonJsonPointerValueLocator(String pointerString)
+    {
+        this.pointer = JsonPointer.compile(pointerString);
+    }
+
+    public JacksonJsonPointerValueLocator(JsonPointer pointer)
+    {
+        this.pointer = pointer;
+    }
+
+    @Override
+    public JsonNode locateValue(ObjectNode record)
+    {
+        return record.at(this.pointer);
+    }
+
+    private final JsonPointer pointer;
+}


### PR DESCRIPTION
See a sample usage below.

Response:
```
{
  "foo": {
    "bar": {
      "id": 123
    }
  }
}
```

Building `ServiceResponseSchema` to read that `123`.
```
        JacksonServiceResponseSchema.builder()
            // Reading "/foo/bar/id" as Embulk's column "id".
            .add(new JacksonJsonPointerValueLocator("/foo/bar/id"), "id", Types.LONG)
        ...
```
