### PR TITLE
Make base classes independent from a generics parameter of |ValueLocator|. (#19)

### DIFF
--- a/src/main/java/org/embulk/base/restclient/JacksonServiceResponseSchema.java
+++ b/src/main/java/org/embulk/base/restclient/JacksonServiceResponseSchema.java
@@ -50,13 +50,13 @@ public final class JacksonServiceResponseSchema
     }
 
     @Override
-    public SchemaWriter<JacksonValueLocator> createSchemaWriter()
+    public SchemaWriter createSchemaWriter()
     {
-        ImmutableList.Builder<ColumnWriter<JacksonValueLocator>> listBuilder = ImmutableList.builder();
+        ImmutableList.Builder<ColumnWriter> listBuilder = ImmutableList.builder();
         for (Map.Entry<Column, ColumnOptions<JacksonValueLocator>> entry : entries()) {
             listBuilder.add(createColumnWriter(entry.getKey(), entry.getValue()));
         }
-        return new SchemaWriter<JacksonValueLocator>(listBuilder.build());
+        return new SchemaWriter(listBuilder.build());
     }
 
     public static final class Builder
@@ -122,23 +122,23 @@ public final class JacksonServiceResponseSchema
         private int index;
     }
 
-    private ColumnWriter<JacksonValueLocator> createColumnWriter(Column column,
-                                                                 ColumnOptions<JacksonValueLocator> columnOptions)
+    private ColumnWriter createColumnWriter(Column column,
+                                            ColumnOptions<JacksonValueLocator> columnOptions)
     {
         Type type = column.getType();
         JacksonValueLocator locator = columnOptions.getValueLocator();
         Optional<String> timestampFormat = columnOptions.getTimestampFormat();
         if (type.equals(Types.BOOLEAN)) {
-            return new BooleanColumnWriter<JacksonValueLocator>(column, locator);
+            return new BooleanColumnWriter(column, locator);
         }
         else if (type.equals(Types.DOUBLE)) {
-            return new DoubleColumnWriter<JacksonValueLocator>(column, locator);
+            return new DoubleColumnWriter(column, locator);
         }
         else if (type.equals(Types.LONG)) {
-            return new LongColumnWriter<JacksonValueLocator>(column, locator);
+            return new LongColumnWriter(column, locator);
         }
         else if (type.equals(Types.STRING)) {
-            return new StringColumnWriter<JacksonValueLocator>(column, locator);
+            return new StringColumnWriter(column, locator);
         }
         else if (type.equals(Types.TIMESTAMP)) {
             TimestampParser timestampParser = new TimestampParser(
@@ -146,11 +146,11 @@ public final class JacksonServiceResponseSchema
                 (timestampFormat.isPresent()
                  ? Exec.newConfigSource().set("format", timestampFormat.get())
                  : Exec.newConfigSource()).loadConfig(TimestampParser.TimestampColumnOption.class));
-            return new TimestampColumnWriter<JacksonValueLocator>(column, locator, timestampParser);
+            return new TimestampColumnWriter(column, locator, timestampParser);
         }
         else if (type.equals(Types.JSON)) {
             JsonParser jsonParser = new JsonParser();
-            return new JsonColumnWriter<JacksonValueLocator>(column, locator, jsonParser);
+            return new JsonColumnWriter(column, locator, jsonParser);
         }
         else {
             throw new IllegalStateException();

--- a/src/main/java/org/embulk/base/restclient/PageLoadable.java
+++ b/src/main/java/org/embulk/base/restclient/PageLoadable.java
@@ -2,11 +2,10 @@ package org.embulk.base.restclient;
 
 import org.embulk.spi.PageBuilder;
 
-import org.embulk.base.restclient.record.ValueLocator;
 import org.embulk.base.restclient.request.RetryHelper;
 import org.embulk.base.restclient.writer.SchemaWriter;
 
-public interface PageLoadable<T extends RestClientTaskBase, U extends ValueLocator>
+public interface PageLoadable<T extends RestClientTaskBase>
 {
-    public void loadPage(T task, RetryHelper retryHelper, SchemaWriter<U> schemaWriter, int taskCount, PageBuilder pageBuilderToLoad);
+    public void loadPage(T task, RetryHelper retryHelper, SchemaWriter schemaWriter, int taskCount, PageBuilder pageBuilderToLoad);
 }

--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginBase.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginBase.java
@@ -10,16 +10,14 @@ import org.embulk.spi.InputPlugin;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
 
-import org.embulk.base.restclient.record.ValueLocator;
-
-public class RestClientInputPluginBase<T extends RestClientInputTaskBase, U extends ValueLocator>
-        extends RestClientInputPluginFragileBase<T, U>
+public class RestClientInputPluginBase<T extends RestClientInputTaskBase>
+        extends RestClientInputPluginFragileBase<T>
 {
     protected RestClientInputPluginBase(Class<T> taskClass,
                                         ClientCreatable<T> clientCreator,
                                         ConfigDiffBuildable<T> configDiffBuilder,
-                                        ServiceResponseSchemaBuildable<U> serviceResponseSchemaBuilder,
-                                        PageLoadable<T, U> pageLoader,
+                                        ServiceResponseSchemaBuildable serviceResponseSchemaBuilder,
+                                        PageLoadable<T> pageLoader,
                                         TaskReportBuildable<T> taskReportBuilder,
                                         TaskValidatable<T> taskValidator,
                                         int taskCount)
@@ -35,7 +33,7 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase, U exte
     }
 
     protected RestClientInputPluginBase(Class<T> taskClass,
-                                        RestClientInputPluginDelegate<T, U> delegate,
+                                        RestClientInputPluginDelegate<T> delegate,
                                         int taskCount)
     {
         super(taskClass, delegate, delegate, delegate, delegate, delegate, delegate, taskCount);

--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginDelegate.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginDelegate.java
@@ -2,11 +2,11 @@ package org.embulk.base.restclient;
 
 import org.embulk.base.restclient.record.ValueLocator;
 
-public interface RestClientInputPluginDelegate<T extends RestClientInputTaskBase, U extends ValueLocator>
+public interface RestClientInputPluginDelegate<T extends RestClientInputTaskBase>
         extends ClientCreatable<T>,
                 ConfigDiffBuildable<T>,
-                PageLoadable<T,U>,
-                ServiceResponseSchemaBuildable<U>,
+                PageLoadable<T>,
+                ServiceResponseSchemaBuildable,
                 TaskReportBuildable<T>,
                 TaskValidatable<T>
 {

--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginFragileBase.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginFragileBase.java
@@ -12,19 +12,18 @@ import org.embulk.spi.PageBuilder;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
 
-import org.embulk.base.restclient.record.ValueLocator;
 import org.embulk.base.restclient.request.AutoCloseableClient;
 import org.embulk.base.restclient.request.RetryHelper;
 
-public class RestClientInputPluginFragileBase<T extends RestClientInputTaskBase, U extends ValueLocator>
+public class RestClientInputPluginFragileBase<T extends RestClientInputTaskBase>
         extends RestClientPluginBase<T>
         implements InputPlugin
 {
     protected RestClientInputPluginFragileBase(Class<T> taskClass,
                                                ClientCreatable<T> clientCreator,
                                                ConfigDiffBuildable<T> configDiffBuilder,
-                                               ServiceResponseSchemaBuildable<U> serviceResponseSchemaBuilder,
-                                               PageLoadable<T,U> pageLoader,
+                                               ServiceResponseSchemaBuildable serviceResponseSchemaBuilder,
+                                               PageLoadable<T> pageLoader,
                                                TaskReportBuildable<T> taskReportBuilder,
                                                TaskValidatable<T> taskValidator,
                                                int taskCount)
@@ -40,7 +39,7 @@ public class RestClientInputPluginFragileBase<T extends RestClientInputTaskBase,
     }
 
     protected RestClientInputPluginFragileBase(Class<T> taskClass,
-                                               RestClientInputPluginDelegate<T,U> delegate,
+                                               RestClientInputPluginDelegate<T> delegate,
                                                int taskCount)
     {
         this(taskClass, delegate, delegate, delegate, delegate, delegate, delegate, taskCount);
@@ -105,8 +104,8 @@ public class RestClientInputPluginFragileBase<T extends RestClientInputTaskBase,
     private final Class<T> taskClass;
     private final ClientCreatable<T> clientCreator;
     private final ConfigDiffBuildable<T> configDiffBuilder;
-    private final PageLoadable<T,U> pageLoader;
-    private final ServiceResponseSchema<U> serviceResponseSchema;
+    private final PageLoadable<T> pageLoader;
+    private final ServiceResponseSchema serviceResponseSchema;
     private final TaskReportBuildable<T> taskReportBuilder;
     private final TaskValidatable<T> taskValidator;
     private final int taskCount;

--- a/src/main/java/org/embulk/base/restclient/ServiceResponseSchema.java
+++ b/src/main/java/org/embulk/base/restclient/ServiceResponseSchema.java
@@ -31,7 +31,7 @@ public abstract class ServiceResponseSchema<T extends ValueLocator>
         return new Schema(ImmutableList.copyOf(map.keys()));
     }
 
-    public abstract SchemaWriter<T> createSchemaWriter();
+    public abstract SchemaWriter createSchemaWriter();
 
     protected final Collection<Map.Entry<Column, ColumnOptions<T>>> entries()
     {

--- a/src/main/java/org/embulk/base/restclient/ServiceResponseSchemaBuildable.java
+++ b/src/main/java/org/embulk/base/restclient/ServiceResponseSchemaBuildable.java
@@ -1,9 +1,6 @@
 package org.embulk.base.restclient;
 
-import org.embulk.base.restclient.ServiceResponseSchema;
-import org.embulk.base.restclient.record.ValueLocator;
-
-public interface ServiceResponseSchemaBuildable<T extends ValueLocator>
+public interface ServiceResponseSchemaBuildable
 {
-    public ServiceResponseSchema<T> buildServiceResponseSchema();
+    public ServiceResponseSchema buildServiceResponseSchema();
 }

--- a/src/main/java/org/embulk/base/restclient/record/JacksonServiceRecord.java
+++ b/src/main/java/org/embulk/base/restclient/record/JacksonServiceRecord.java
@@ -3,7 +3,7 @@ package org.embulk.base.restclient.record;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class JacksonServiceRecord
-        extends ServiceRecord<JacksonValueLocator>
+        extends ServiceRecord
 {
     public JacksonServiceRecord(ObjectNode record)
     {
@@ -11,9 +11,13 @@ public class JacksonServiceRecord
     }
 
     @Override
-    public JacksonServiceValue getValue(JacksonValueLocator locator)
+    public JacksonServiceValue getValue(ValueLocator locator)
     {
-        return new JacksonServiceValue(locator.locateValue(record));
+        if (locator instanceof JacksonValueLocator) {
+            JacksonValueLocator jacksonLocator = (JacksonValueLocator) locator;
+            return new JacksonServiceValue(jacksonLocator.locateValue(record));
+        }
+        throw new RuntimeException("Non-JacksonValueLocator is used to locate a value in JacksonServiceRecord");
     }
 
     private ObjectNode record;

--- a/src/main/java/org/embulk/base/restclient/record/ServiceRecord.java
+++ b/src/main/java/org/embulk/base/restclient/record/ServiceRecord.java
@@ -1,6 +1,6 @@
 package org.embulk.base.restclient.record;
 
-public abstract class ServiceRecord<T extends ValueLocator>
+public abstract class ServiceRecord
 {
-    public abstract ServiceValue getValue(T locator);
+    public abstract ServiceValue getValue(ValueLocator locator);
 }

--- a/src/main/java/org/embulk/base/restclient/writer/BooleanColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/BooleanColumnWriter.java
@@ -7,16 +7,16 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class BooleanColumnWriter<T extends ValueLocator>
-        extends ColumnWriter<T>
+public class BooleanColumnWriter
+        extends ColumnWriter
 {
-    public BooleanColumnWriter(Column column, T valueLocator)
+    public BooleanColumnWriter(Column column, ValueLocator valueLocator)
     {
         super(column, valueLocator);
     }
 
     @Override
-    public void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
+    public void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad)
     {
         ServiceValue value = pickupValueResponsible(record);
         if (value == null || value.isNull()) {

--- a/src/main/java/org/embulk/base/restclient/writer/ColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/ColumnWriter.java
@@ -7,26 +7,26 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public abstract class ColumnWriter<T extends ValueLocator>
+public abstract class ColumnWriter
 {
-    protected ColumnWriter(Column column, T valueLocator)
+    protected ColumnWriter(Column column, ValueLocator valueLocator)
     {
         this.column = column;
         this.valueLocator = valueLocator;
     }
 
-    public abstract void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad);
+    public abstract void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad);
 
     protected final Column getColumnResponsible()
     {
         return column;
     }
 
-    protected final ServiceValue pickupValueResponsible(ServiceRecord<T> record)
+    protected final ServiceValue pickupValueResponsible(ServiceRecord record)
     {
         return record.getValue(valueLocator);
     }
 
     private final Column column;
-    private final T valueLocator;
+    private final ValueLocator valueLocator;
 }

--- a/src/main/java/org/embulk/base/restclient/writer/DoubleColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/DoubleColumnWriter.java
@@ -7,16 +7,16 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class DoubleColumnWriter<T extends ValueLocator>
-        extends ColumnWriter<T>
+public class DoubleColumnWriter
+        extends ColumnWriter
 {
-    public DoubleColumnWriter(Column column, T valueLocator)
+    public DoubleColumnWriter(Column column, ValueLocator valueLocator)
     {
         super(column, valueLocator);
     }
 
     @Override
-    public void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
+    public void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad)
     {
         ServiceValue value = pickupValueResponsible(record);
         if (value == null || value.isNull()) {

--- a/src/main/java/org/embulk/base/restclient/writer/JsonColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/JsonColumnWriter.java
@@ -8,17 +8,17 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class JsonColumnWriter<T extends ValueLocator>
-        extends ColumnWriter<T>
+public class JsonColumnWriter
+        extends ColumnWriter
 {
-    public JsonColumnWriter(Column column, T valueLocator, JsonParser jsonParser)
+    public JsonColumnWriter(Column column, ValueLocator valueLocator, JsonParser jsonParser)
     {
         super(column, valueLocator);
         this.jsonParser = jsonParser;
     }
 
     @Override
-    public void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
+    public void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad)
     {
         ServiceValue value = pickupValueResponsible(record);
         if (value == null || value.isNull()) {

--- a/src/main/java/org/embulk/base/restclient/writer/LongColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/LongColumnWriter.java
@@ -7,16 +7,16 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class LongColumnWriter<T extends ValueLocator>
-        extends ColumnWriter<T>
+public class LongColumnWriter
+        extends ColumnWriter
 {
-    public LongColumnWriter(Column column, T valueLocator)
+    public LongColumnWriter(Column column, ValueLocator valueLocator)
     {
         super(column, valueLocator);
     }
 
     @Override
-    public void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
+    public void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad)
     {
         ServiceValue value = pickupValueResponsible(record);
         if (value == null || value.isNull()) {

--- a/src/main/java/org/embulk/base/restclient/writer/SchemaWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/SchemaWriter.java
@@ -7,20 +7,20 @@ import org.embulk.spi.PageBuilder;
 import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class SchemaWriter<T extends ValueLocator>
+public class SchemaWriter
 {
-    public SchemaWriter(List<ColumnWriter<T>> columnWriters)
+    public SchemaWriter(List<ColumnWriter> columnWriters)
     {
         this.columnWriters = columnWriters;
     }
 
-    public void addRecordTo(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
+    public void addRecordTo(ServiceRecord record, PageBuilder pageBuilderToLoad)
     {
-        for (ColumnWriter<T> columnWriter : columnWriters) {
+        for (ColumnWriter columnWriter : columnWriters) {
             columnWriter.writeColumnResponsible(record, pageBuilderToLoad);
         }
         pageBuilderToLoad.addRecord();
     }
 
-    private List<ColumnWriter<T>> columnWriters;
+    private List<ColumnWriter> columnWriters;
 }

--- a/src/main/java/org/embulk/base/restclient/writer/StringColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/StringColumnWriter.java
@@ -7,16 +7,16 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class StringColumnWriter<T extends ValueLocator>
-        extends ColumnWriter<T>
+public class StringColumnWriter
+        extends ColumnWriter
 {
-    public StringColumnWriter(Column column, T valueLocator)
+    public StringColumnWriter(Column column, ValueLocator valueLocator)
     {
         super(column, valueLocator);
     }
 
     @Override
-    public void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
+    public void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad)
     {
         ServiceValue value = pickupValueResponsible(record);
         if (value == null || value.isNull()) {

--- a/src/main/java/org/embulk/base/restclient/writer/TimestampColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/TimestampColumnWriter.java
@@ -8,17 +8,17 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class TimestampColumnWriter<T extends ValueLocator>
-        extends ColumnWriter<T>
+public class TimestampColumnWriter
+        extends ColumnWriter
 {
-    public TimestampColumnWriter(Column column, T valueLocator, TimestampParser timestampParser)
+    public TimestampColumnWriter(Column column, ValueLocator valueLocator, TimestampParser timestampParser)
     {
         super(column, valueLocator);
         this.timestampParser = timestampParser;
     }
 
     @Override
-    public void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
+    public void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad)
     {
         ServiceValue value = pickupValueResponsible(record);
         if (value == null || value.isNull()) {

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPlugin.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPlugin.java
@@ -1,10 +1,9 @@
 package org.embulk.input.shopify;
 
 import org.embulk.base.restclient.RestClientInputPluginBase;
-import org.embulk.base.restclient.record.JacksonValueLocator;
 
 public class ShopifyInputPlugin
-        extends RestClientInputPluginBase<ShopifyInputPluginDelegate.PluginTask, JacksonValueLocator>
+        extends RestClientInputPluginBase<ShopifyInputPluginDelegate.PluginTask>
 {
     public ShopifyInputPlugin()
     {

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
@@ -37,7 +37,7 @@ import org.embulk.base.restclient.request.SingleRequester;
 import org.embulk.base.restclient.writer.SchemaWriter;
 
 public class ShopifyInputPluginDelegate
-    implements RestClientInputPluginDelegate<ShopifyInputPluginDelegate.PluginTask, JacksonValueLocator>
+    implements RestClientInputPluginDelegate<ShopifyInputPluginDelegate.PluginTask>
 {
     public interface PluginTask
             extends RestClientInputTaskBase
@@ -127,7 +127,7 @@ public class ShopifyInputPluginDelegate
     @Override  // Overridden from |PageLoadable|
     public void loadPage(final PluginTask task,
                          RetryHelper retryHelper,
-                         SchemaWriter<JacksonValueLocator> schemaWriter,
+                         SchemaWriter schemaWriter,
                          int taskCount,
                          PageBuilder pageBuilderToLoad)
     {


### PR DESCRIPTION
@muga After some thoughts, trying to make the base classes independent from the generics parameter of `ValueLocator`.

Although it introduces [a little bit "dirty-typing" point to implement a `ServiceRecord`](https://github.com/dmikurube/embulk-base-restclient/compare/master...dmikurube:independent-value-locator?expand=1#diff-42ee28d76e415033362eab010d4e502eR16), it has a couple of benefits like:

* Developers (users of this library) need to take care of **less** complicated generics parameters.
* The library can handle a kind of REST services which returns different content types per endpoint. (See #19)

Note that simple developers (just users of this library) do not need to handle the "dirty-typing". Only those who extend this library (e.g. extend for XML) need to care.