### PR TITLE
Retry reading a JAX-RS |Response| within |RetryHelper|.

### DIFF
--- a/src/main/java/org/embulk/base/restclient/request/InputStreamResponseEntityReader.java
+++ b/src/main/java/org/embulk/base/restclient/request/InputStreamResponseEntityReader.java
@@ -1,0 +1,12 @@
+package org.embulk.base.restclient.request;
+
+import java.io.InputStream;
+
+public class InputStreamResponseEntityReader
+        implements ResponseReadable<InputStream>
+{
+    public final InputStream readResponse(javax.ws.rs.core.Response response)
+    {
+        return response.readEntity(InputStream.class);
+    }
+}

--- a/src/main/java/org/embulk/base/restclient/request/ResponseReadable.java
+++ b/src/main/java/org/embulk/base/restclient/request/ResponseReadable.java
@@ -1,0 +1,17 @@
+package org.embulk.base.restclient.request;
+
+/**
+ * ResponseReadable defines a method that reads (understands) JAX-RS {@code Response} to another type.
+ *
+ * This is prepared so that reading a JAX-RS {@code Response} can be retried in
+ * {@code RetryHelper}. If {@code RetryHelper} returns just JAX-RS
+ * {@code Response}, developers need to call {@code Response#readEntity} or else
+ * by themselves, and retry by themselves as well.
+ *
+ * Find some predefined {@code ResponseReadable} implementations such as
+ * {@code StringResponseEntityReader}.
+ */
+public interface ResponseReadable<T>
+{
+    T readResponse(javax.ws.rs.core.Response response);
+}

--- a/src/main/java/org/embulk/base/restclient/request/RetryHelper.java
+++ b/src/main/java/org/embulk/base/restclient/request/RetryHelper.java
@@ -23,7 +23,8 @@ public class RetryHelper
         this.maxRetryWait = maxRetryWait;
     }
 
-    public javax.ws.rs.core.Response requestWithRetry(final SingleRequester singleRequester)
+    public <T> T requestWithRetry(final ResponseReadable<T> responseReader,
+                                  final SingleRequester singleRequester)
     {
         try {
             return RetryExecutor
@@ -31,9 +32,9 @@ public class RetryHelper
                 .withRetryLimit(retryLimit)
                 .withInitialRetryWait(initialRetryWait)
                 .withMaxRetryWait(maxRetryWait)
-                .runInterruptible(new RetryExecutor.Retryable<javax.ws.rs.core.Response>() {
+                .runInterruptible(new RetryExecutor.Retryable<T>() {
                         @Override
-                        public javax.ws.rs.core.Response call()
+                        public T call()
                                 throws Exception
                         {
                             // |javax.ws.rs.ProcessingException| can be throws
@@ -44,7 +45,7 @@ public class RetryHelper
                                 throw new javax.ws.rs.WebApplicationException(response);
                             }
 
-                            return response;
+                            return responseReader.readResponse(response);
                         }
 
                         @Override

--- a/src/main/java/org/embulk/base/restclient/request/SingleRequester.java
+++ b/src/main/java/org/embulk/base/restclient/request/SingleRequester.java
@@ -7,20 +7,24 @@ package org.embulk.base.restclient.request;
  *
  * <pre>{@code
  * javax.ws.rs.core.Response response = retryHelper.requestWithRetry(
+ *     new StringResponseEntityReader(),
  *     new SingleRequester() {
- *         @Override
- *         public boolean isResponseStatusRetryable(javax.ws.rs.core.Response response)
- *         {
- *             return (response.getStatus() / 100) == 4;
- *         }
- *
  *         @Override
  *         public Response requestOnce(javax.ws.rs.client.Client client)
  *         {
  *             return client.target("https://example.com/api/resource").request().get;
  *         }
+ *
+ *         @Override
+ *         public boolean isResponseStatusToRetry(javax.ws.rs.core.Response response)
+ *         {
+ *             return (response.getStatus() / 100) == 4;
+ *         }
  *     });
  * }</pre>
+ *
+ * @see ResponseReadable
+ * @see StringResponseEntityReader
  */
 abstract public class SingleRequester
 {

--- a/src/main/java/org/embulk/base/restclient/request/StringResponseEntityReader.java
+++ b/src/main/java/org/embulk/base/restclient/request/StringResponseEntityReader.java
@@ -1,0 +1,10 @@
+package org.embulk.base.restclient.request;
+
+public class StringResponseEntityReader
+        implements ResponseReadable<String>
+{
+    public final String readResponse(javax.ws.rs.core.Response response)
+    {
+        return response.readEntity(String.class);
+    }
+}

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
@@ -34,6 +34,7 @@ import org.embulk.base.restclient.record.JacksonServiceRecord;
 import org.embulk.base.restclient.record.JacksonValueLocator;
 import org.embulk.base.restclient.request.RetryHelper;
 import org.embulk.base.restclient.request.SingleRequester;
+import org.embulk.base.restclient.request.StringResponseEntityReader;
 import org.embulk.base.restclient.writer.SchemaWriter;
 
 public class ShopifyInputPluginDelegate
@@ -133,10 +134,7 @@ public class ShopifyInputPluginDelegate
     {
         int pageIndex = 1;
         while (true) {
-            javax.ws.rs.core.Response response = fetchFromShopify(retryHelper, task, pageIndex);
-
-            // |javax.ws.rs.ProcessingException| can be thrown due to read timeout.
-            String content = response.readEntity(String.class);
+            String content = fetchFromShopify(retryHelper, task, pageIndex);
             ArrayNode records = extractArrayField(content);
 
             int count = 0;
@@ -176,11 +174,12 @@ public class ShopifyInputPluginDelegate
         }
     }
 
-    private javax.ws.rs.core.Response fetchFromShopify(RetryHelper retryHelper,
-                                                       final PluginTask task,
-                                                       final int pageIndex)
+    private String fetchFromShopify(RetryHelper retryHelper,
+                                    final PluginTask task,
+                                    final int pageIndex)
     {
         return retryHelper.requestWithRetry(
+            new StringResponseEntityReader(),
             new SingleRequester() {
                 @Override
                 public Response requestOnce(javax.ws.rs.client.Client client)


### PR DESCRIPTION
Instead of #18, trying to retry reading a response without generics: for #19.

Will rebase after #20 is merged.