### PR TITLE
Build |ServiceResponseSchema| based on |Task|.

### DIFF
--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginBase.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginBase.java
@@ -16,7 +16,7 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase>
     protected RestClientInputPluginBase(Class<T> taskClass,
                                         ClientCreatable<T> clientCreator,
                                         ConfigDiffBuildable<T> configDiffBuilder,
-                                        ServiceResponseSchemaBuildable serviceResponseSchemaBuilder,
+                                        ServiceResponseSchemaBuildable<T> serviceResponseSchemaBuilder,
                                         PageLoadable<T> pageLoader,
                                         TaskReportBuildable<T> taskReportBuilder,
                                         TaskValidatable<T> taskValidator,

--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginDelegate.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginDelegate.java
@@ -6,7 +6,7 @@ public interface RestClientInputPluginDelegate<T extends RestClientInputTaskBase
         extends ClientCreatable<T>,
                 ConfigDiffBuildable<T>,
                 PageLoadable<T>,
-                ServiceResponseSchemaBuildable,
+                ServiceResponseSchemaBuildable<T>,
                 TaskReportBuildable<T>,
                 TaskValidatable<T>
 {

--- a/src/main/java/org/embulk/base/restclient/ServiceResponseSchemaBuildable.java
+++ b/src/main/java/org/embulk/base/restclient/ServiceResponseSchemaBuildable.java
@@ -1,6 +1,6 @@
 package org.embulk.base.restclient;
 
-public interface ServiceResponseSchemaBuildable
+public interface ServiceResponseSchemaBuildable<T extends RestClientInputTaskBase>
 {
-    public ServiceResponseSchema buildServiceResponseSchema();
+    public ServiceResponseSchema buildServiceResponseSchema(T task);
 }

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
@@ -91,7 +91,7 @@ public class ShopifyInputPluginDelegate
     }
 
     @Override  // Overridden from |ServiceResponseSchemaBuildable|
-    public JacksonServiceResponseSchema buildServiceResponseSchema()
+    public JacksonServiceResponseSchema buildServiceResponseSchema(PluginTask task)
     {
         return JacksonServiceResponseSchema.builder()
             .add("id", Types.LONG)


### PR DESCRIPTION
For #19, `ServiceResponseSchema` is also to be generated through `Task`. It allows developers to use the library for multiple endpoints per `Task`/`Config` such as:

```
in:
    type: example_rest_service
    endpoint_type: users  # Accessing to api.example.com/users
```

```
in:
    type: some_rest_service
    endpoint_type: items  # Accessing to api.example.com/items which has a different JSON format
```
