### PR TITLE
Eliminate dynamic type checking in |JacksonServiceRecord|.

### DIFF
--- a/src/main/java/org/embulk/base/restclient/JacksonServiceResponseSchema.java
+++ b/src/main/java/org/embulk/base/restclient/JacksonServiceResponseSchema.java
@@ -50,13 +50,13 @@ public final class JacksonServiceResponseSchema
     }
 
     @Override
-    public SchemaWriter createSchemaWriter()
+    public SchemaWriter<JacksonValueLocator> createSchemaWriter()
     {
-        ImmutableList.Builder<ColumnWriter> listBuilder = ImmutableList.builder();
+        ImmutableList.Builder<ColumnWriter<JacksonValueLocator>> listBuilder = ImmutableList.builder();
         for (Map.Entry<Column, ColumnOptions<JacksonValueLocator>> entry : entries()) {
             listBuilder.add(createColumnWriter(entry.getKey(), entry.getValue()));
         }
-        return new SchemaWriter(listBuilder.build());
+        return new SchemaWriter<JacksonValueLocator>(listBuilder.build());
     }
 
     public static final class Builder
@@ -122,23 +122,23 @@ public final class JacksonServiceResponseSchema
         private int index;
     }
 
-    private ColumnWriter createColumnWriter(Column column,
-                                            ColumnOptions<JacksonValueLocator> columnOptions)
+    private ColumnWriter<JacksonValueLocator> createColumnWriter(Column column,
+                                                                 ColumnOptions<JacksonValueLocator> columnOptions)
     {
         Type type = column.getType();
         JacksonValueLocator locator = columnOptions.getValueLocator();
         Optional<String> timestampFormat = columnOptions.getTimestampFormat();
         if (type.equals(Types.BOOLEAN)) {
-            return new BooleanColumnWriter(column, locator);
+            return new BooleanColumnWriter<JacksonValueLocator>(column, locator);
         }
         else if (type.equals(Types.DOUBLE)) {
-            return new DoubleColumnWriter(column, locator);
+            return new DoubleColumnWriter<JacksonValueLocator>(column, locator);
         }
         else if (type.equals(Types.LONG)) {
-            return new LongColumnWriter(column, locator);
+            return new LongColumnWriter<JacksonValueLocator>(column, locator);
         }
         else if (type.equals(Types.STRING)) {
-            return new StringColumnWriter(column, locator);
+            return new StringColumnWriter<JacksonValueLocator>(column, locator);
         }
         else if (type.equals(Types.TIMESTAMP)) {
             TimestampParser timestampParser = new TimestampParser(
@@ -146,11 +146,11 @@ public final class JacksonServiceResponseSchema
                 (timestampFormat.isPresent()
                  ? Exec.newConfigSource().set("format", timestampFormat.get())
                  : Exec.newConfigSource()).loadConfig(TimestampParser.TimestampColumnOption.class));
-            return new TimestampColumnWriter(column, locator, timestampParser);
+            return new TimestampColumnWriter<JacksonValueLocator>(column, locator, timestampParser);
         }
         else if (type.equals(Types.JSON)) {
             JsonParser jsonParser = new JsonParser();
-            return new JsonColumnWriter(column, locator, jsonParser);
+            return new JsonColumnWriter<JacksonValueLocator>(column, locator, jsonParser);
         }
         else {
             throw new IllegalStateException();

--- a/src/main/java/org/embulk/base/restclient/PageLoadable.java
+++ b/src/main/java/org/embulk/base/restclient/PageLoadable.java
@@ -2,10 +2,11 @@ package org.embulk.base.restclient;
 
 import org.embulk.spi.PageBuilder;
 
+import org.embulk.base.restclient.record.ValueLocator;
 import org.embulk.base.restclient.request.RetryHelper;
 import org.embulk.base.restclient.writer.SchemaWriter;
 
 public interface PageLoadable<T extends RestClientTaskBase>
 {
-    public void loadPage(T task, RetryHelper retryHelper, SchemaWriter schemaWriter, int taskCount, PageBuilder pageBuilderToLoad);
+    public void loadPage(T task, RetryHelper retryHelper, SchemaWriter<? extends ValueLocator> schemaWriter, int taskCount, PageBuilder pageBuilderToLoad);
 }

--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginFragileBase.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginFragileBase.java
@@ -12,6 +12,7 @@ import org.embulk.spi.PageBuilder;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
 
+import org.embulk.base.restclient.record.ValueLocator;
 import org.embulk.base.restclient.request.AutoCloseableClient;
 import org.embulk.base.restclient.request.RetryHelper;
 
@@ -75,7 +76,7 @@ public class RestClientInputPluginFragileBase<T extends RestClientInputTaskBase>
     public TaskReport run(TaskSource taskSource, Schema schema, int taskIndex, PageOutput output)
     {
         T task = taskSource.loadTask(this.taskClass);
-        ServiceResponseSchema serviceResponseSchema =
+        ServiceResponseSchema<? extends ValueLocator> serviceResponseSchema =
             this.serviceResponseSchemaBuilder.buildServiceResponseSchema(task);
         try (PageBuilder pageBuilder = new PageBuilder(Exec.getBufferAllocator(), schema, output)) {
             try (AutoCloseableClient<T> clientWrapper = new AutoCloseableClient<T>(task, this.clientCreator)) {

--- a/src/main/java/org/embulk/base/restclient/ServiceResponseSchema.java
+++ b/src/main/java/org/embulk/base/restclient/ServiceResponseSchema.java
@@ -31,7 +31,7 @@ public abstract class ServiceResponseSchema<T extends ValueLocator>
         return new Schema(ImmutableList.copyOf(map.keys()));
     }
 
-    public abstract SchemaWriter createSchemaWriter();
+    public abstract SchemaWriter<T> createSchemaWriter();
 
     protected final Collection<Map.Entry<Column, ColumnOptions<T>>> entries()
     {

--- a/src/main/java/org/embulk/base/restclient/ServiceResponseSchemaBuildable.java
+++ b/src/main/java/org/embulk/base/restclient/ServiceResponseSchemaBuildable.java
@@ -1,6 +1,8 @@
 package org.embulk.base.restclient;
 
+import org.embulk.base.restclient.record.ValueLocator;
+
 public interface ServiceResponseSchemaBuildable<T extends RestClientInputTaskBase>
 {
-    public ServiceResponseSchema buildServiceResponseSchema(T task);
+    public ServiceResponseSchema<? extends ValueLocator> buildServiceResponseSchema(T task);
 }

--- a/src/main/java/org/embulk/base/restclient/record/JacksonServiceRecord.java
+++ b/src/main/java/org/embulk/base/restclient/record/JacksonServiceRecord.java
@@ -3,7 +3,7 @@ package org.embulk.base.restclient.record;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class JacksonServiceRecord
-        extends ServiceRecord
+        extends ServiceRecord<JacksonValueLocator>
 {
     public JacksonServiceRecord(ObjectNode record)
     {
@@ -11,13 +11,9 @@ public class JacksonServiceRecord
     }
 
     @Override
-    public JacksonServiceValue getValue(ValueLocator locator)
+    public JacksonServiceValue getValue(JacksonValueLocator locator)
     {
-        if (locator instanceof JacksonValueLocator) {
-            JacksonValueLocator jacksonLocator = (JacksonValueLocator) locator;
-            return new JacksonServiceValue(jacksonLocator.locateValue(record));
-        }
-        throw new RuntimeException("Non-JacksonValueLocator is used to locate a value in JacksonServiceRecord");
+        return new JacksonServiceValue(locator.locateValue(record));
     }
 
     private ObjectNode record;

--- a/src/main/java/org/embulk/base/restclient/record/ServiceRecord.java
+++ b/src/main/java/org/embulk/base/restclient/record/ServiceRecord.java
@@ -1,6 +1,6 @@
 package org.embulk.base.restclient.record;
 
-public abstract class ServiceRecord
+public abstract class ServiceRecord<T extends ValueLocator>
 {
-    public abstract ServiceValue getValue(ValueLocator locator);
+    public abstract ServiceValue getValue(T locator);
 }

--- a/src/main/java/org/embulk/base/restclient/writer/BooleanColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/BooleanColumnWriter.java
@@ -7,16 +7,16 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class BooleanColumnWriter
-        extends ColumnWriter
+public class BooleanColumnWriter<T extends ValueLocator>
+        extends ColumnWriter<T>
 {
-    public BooleanColumnWriter(Column column, ValueLocator valueLocator)
+    public BooleanColumnWriter(Column column, T valueLocator)
     {
         super(column, valueLocator);
     }
 
     @Override
-    public void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad)
+    public void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
     {
         ServiceValue value = pickupValueResponsible(record);
         if (value == null || value.isNull()) {

--- a/src/main/java/org/embulk/base/restclient/writer/ColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/ColumnWriter.java
@@ -7,26 +7,26 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public abstract class ColumnWriter
+public abstract class ColumnWriter<T extends ValueLocator>
 {
-    protected ColumnWriter(Column column, ValueLocator valueLocator)
+    protected ColumnWriter(Column column, T valueLocator)
     {
         this.column = column;
         this.valueLocator = valueLocator;
     }
 
-    public abstract void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad);
+    public abstract void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad);
 
     protected final Column getColumnResponsible()
     {
         return column;
     }
 
-    protected final ServiceValue pickupValueResponsible(ServiceRecord record)
+    protected final ServiceValue pickupValueResponsible(ServiceRecord<T> record)
     {
         return record.getValue(valueLocator);
     }
 
     private final Column column;
-    private final ValueLocator valueLocator;
+    private final T valueLocator;
 }

--- a/src/main/java/org/embulk/base/restclient/writer/DoubleColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/DoubleColumnWriter.java
@@ -7,16 +7,16 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class DoubleColumnWriter
-        extends ColumnWriter
+public class DoubleColumnWriter<T extends ValueLocator>
+        extends ColumnWriter<T>
 {
-    public DoubleColumnWriter(Column column, ValueLocator valueLocator)
+    public DoubleColumnWriter(Column column, T valueLocator)
     {
         super(column, valueLocator);
     }
 
     @Override
-    public void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad)
+    public void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
     {
         ServiceValue value = pickupValueResponsible(record);
         if (value == null || value.isNull()) {

--- a/src/main/java/org/embulk/base/restclient/writer/JsonColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/JsonColumnWriter.java
@@ -8,17 +8,17 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class JsonColumnWriter
-        extends ColumnWriter
+public class JsonColumnWriter<T extends ValueLocator>
+        extends ColumnWriter<T>
 {
-    public JsonColumnWriter(Column column, ValueLocator valueLocator, JsonParser jsonParser)
+    public JsonColumnWriter(Column column, T valueLocator, JsonParser jsonParser)
     {
         super(column, valueLocator);
         this.jsonParser = jsonParser;
     }
 
     @Override
-    public void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad)
+    public void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
     {
         ServiceValue value = pickupValueResponsible(record);
         if (value == null || value.isNull()) {

--- a/src/main/java/org/embulk/base/restclient/writer/LongColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/LongColumnWriter.java
@@ -7,16 +7,16 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class LongColumnWriter
-        extends ColumnWriter
+public class LongColumnWriter<T extends ValueLocator>
+        extends ColumnWriter<T>
 {
-    public LongColumnWriter(Column column, ValueLocator valueLocator)
+    public LongColumnWriter(Column column, T valueLocator)
     {
         super(column, valueLocator);
     }
 
     @Override
-    public void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad)
+    public void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
     {
         ServiceValue value = pickupValueResponsible(record);
         if (value == null || value.isNull()) {

--- a/src/main/java/org/embulk/base/restclient/writer/SchemaWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/SchemaWriter.java
@@ -7,20 +7,20 @@ import org.embulk.spi.PageBuilder;
 import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class SchemaWriter
+public class SchemaWriter<T extends ValueLocator>
 {
-    public SchemaWriter(List<ColumnWriter> columnWriters)
+    public SchemaWriter(List<ColumnWriter<T>> columnWriters)
     {
         this.columnWriters = columnWriters;
     }
 
-    public void addRecordTo(ServiceRecord record, PageBuilder pageBuilderToLoad)
+    public void addRecordTo(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
     {
-        for (ColumnWriter columnWriter : columnWriters) {
+        for (ColumnWriter<T> columnWriter : columnWriters) {
             columnWriter.writeColumnResponsible(record, pageBuilderToLoad);
         }
         pageBuilderToLoad.addRecord();
     }
 
-    private List<ColumnWriter> columnWriters;
+    private List<ColumnWriter<T>> columnWriters;
 }

--- a/src/main/java/org/embulk/base/restclient/writer/StringColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/StringColumnWriter.java
@@ -7,16 +7,16 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class StringColumnWriter
-        extends ColumnWriter
+public class StringColumnWriter<T extends ValueLocator>
+        extends ColumnWriter<T>
 {
-    public StringColumnWriter(Column column, ValueLocator valueLocator)
+    public StringColumnWriter(Column column, T valueLocator)
     {
         super(column, valueLocator);
     }
 
     @Override
-    public void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad)
+    public void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
     {
         ServiceValue value = pickupValueResponsible(record);
         if (value == null || value.isNull()) {

--- a/src/main/java/org/embulk/base/restclient/writer/TimestampColumnWriter.java
+++ b/src/main/java/org/embulk/base/restclient/writer/TimestampColumnWriter.java
@@ -8,17 +8,17 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueLocator;
 
-public class TimestampColumnWriter
-        extends ColumnWriter
+public class TimestampColumnWriter<T extends ValueLocator>
+        extends ColumnWriter<T>
 {
-    public TimestampColumnWriter(Column column, ValueLocator valueLocator, TimestampParser timestampParser)
+    public TimestampColumnWriter(Column column, T valueLocator, TimestampParser timestampParser)
     {
         super(column, valueLocator);
         this.timestampParser = timestampParser;
     }
 
     @Override
-    public void writeColumnResponsible(ServiceRecord record, PageBuilder pageBuilderToLoad)
+    public void writeColumnResponsible(ServiceRecord<T> record, PageBuilder pageBuilderToLoad)
     {
         ServiceValue value = pickupValueResponsible(record);
         if (value == null || value.isNull()) {

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
@@ -32,6 +32,7 @@ import org.embulk.base.restclient.RestClientInputTaskBase;
 import org.embulk.base.restclient.json.StringJsonParser;
 import org.embulk.base.restclient.record.JacksonServiceRecord;
 import org.embulk.base.restclient.record.JacksonValueLocator;
+import org.embulk.base.restclient.record.ValueLocator;
 import org.embulk.base.restclient.request.RetryHelper;
 import org.embulk.base.restclient.request.SingleRequester;
 import org.embulk.base.restclient.request.StringResponseEntityReader;
@@ -128,10 +129,13 @@ public class ShopifyInputPluginDelegate
     @Override  // Overridden from |PageLoadable|
     public void loadPage(final PluginTask task,
                          RetryHelper retryHelper,
-                         SchemaWriter schemaWriter,
+                         SchemaWriter<? extends ValueLocator> schemaWriter,
                          int taskCount,
                          PageBuilder pageBuilderToLoad)
     {
+        @SuppressWarnings("unchecked")
+        SchemaWriter<JacksonValueLocator> jacksonSchemaWriter = (SchemaWriter<JacksonValueLocator>) schemaWriter;
+
         int pageIndex = 1;
         while (true) {
             String content = fetchFromShopify(retryHelper, task, pageIndex);
@@ -145,7 +149,7 @@ public class ShopifyInputPluginDelegate
                 }
 
                 try {
-                    schemaWriter.addRecordTo(
+                    jacksonSchemaWriter.addRecordTo(
                         new JacksonServiceRecord((ObjectNode) record), pageBuilderToLoad);
                 }
                 catch (Exception e) {


### PR DESCRIPTION
Large version of fix for #23. Concerned that it needs developers to cast `SchemaWriter` in `loadPage` by themselves such as:
https://github.com/dmikurube/embulk-base-restclient/pull/25/files#diff-625ea9164325bdd9b6969461114425feR136

```
    @SuppressWarnings("unchecked")
    SchemaWriter<JacksonValueLocator> jacksonSchemaWriter = (SchemaWriter<JacksonValueLocator>) schemaWriter;
```