### PR TITLE
Cast |ValueLocator| without checking, and catch |ClassCastException| in |JacksonServiceRecord|.

### DIFF
--- a/src/main/java/org/embulk/base/restclient/record/JacksonServiceRecord.java
+++ b/src/main/java/org/embulk/base/restclient/record/JacksonServiceRecord.java
@@ -13,11 +13,20 @@ public class JacksonServiceRecord
     @Override
     public JacksonServiceValue getValue(ValueLocator locator)
     {
-        if (locator instanceof JacksonValueLocator) {
-            JacksonValueLocator jacksonLocator = (JacksonValueLocator) locator;
-            return new JacksonServiceValue(jacksonLocator.locateValue(record));
+        // Based on the implementation of |JacksonServiceResponseSchema|,
+        // the |ValueLocator| should be always |JacksonValueLocator|.
+        // The class cast should always success.
+        //
+        // NOTE: Just casting (with catching |ClassCastException|) is
+        // faster than checking (instanceof) and then casting if
+        // the |ClassCastException| never or hardly happens.
+        JacksonValueLocator jacksonLocator;
+        try {
+            jacksonLocator = (JacksonValueLocator) locator;
+        } catch (ClassCastException ex) {
+            throw new RuntimeException("Non-JacksonValueLocator is used to locate a value in JacksonServiceRecord", ex);
         }
-        throw new RuntimeException("Non-JacksonValueLocator is used to locate a value in JacksonServiceRecord");
+        return new JacksonServiceValue(jacksonLocator.locateValue(record));
     }
 
     private ObjectNode record;


### PR DESCRIPTION
Quick reasonable fix for #23.