### PR TITLE
Unify all Jackson dependencies under |org.embulk.base.restclient.jackson|.

### DIFF
--- a/src/main/java/org/embulk/base/restclient/ServiceResponseMapper.java
+++ b/src/main/java/org/embulk/base/restclient/ServiceResponseMapper.java
@@ -38,7 +38,7 @@ public abstract class ServiceResponseMapper<T extends ValueLocator>
         return map.entries();
     }
 
-    protected static class ColumnOptions<U extends ValueLocator>
+    public static class ColumnOptions<U extends ValueLocator>
     {
         public ColumnOptions(U valueLocator)
         {

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonFlatValueLocator.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonFlatValueLocator.java
@@ -1,4 +1,4 @@
-package org.embulk.base.restclient.record;
+package org.embulk.base.restclient.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonJsonPointerValueLocator.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonJsonPointerValueLocator.java
@@ -1,4 +1,4 @@
-package org.embulk.base.restclient.record;
+package org.embulk.base.restclient.jackson;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceRecord.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceRecord.java
@@ -1,6 +1,9 @@
-package org.embulk.base.restclient.record;
+package org.embulk.base.restclient.jackson;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.embulk.base.restclient.record.ServiceRecord;
+import org.embulk.base.restclient.record.ValueLocator;
 
 public class JacksonServiceRecord
         extends ServiceRecord

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceResponseMapper.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceResponseMapper.java
@@ -1,4 +1,4 @@
-package org.embulk.base.restclient;
+package org.embulk.base.restclient.jackson;
 
 import java.util.Map;
 
@@ -14,8 +14,8 @@ import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
 
-import org.embulk.base.restclient.record.JacksonFlatValueLocator;
-import org.embulk.base.restclient.record.JacksonValueLocator;
+import org.embulk.base.restclient.ServiceResponseMapper;
+import org.embulk.base.restclient.ServiceResponseMapper.ColumnOptions;
 import org.embulk.base.restclient.record.RecordImporter;
 import org.embulk.base.restclient.record.ValueImporter;
 import org.embulk.base.restclient.record.values.BooleanValueImporter;

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceValue.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceValue.java
@@ -1,6 +1,8 @@
-package org.embulk.base.restclient.record;
+package org.embulk.base.restclient.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import org.embulk.base.restclient.record.ServiceValue;
 
 /**
  * JacksonServiceValue represents a value in a JSON response to be converted to an Embulk column value.

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonValueLocator.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonValueLocator.java
@@ -1,7 +1,9 @@
-package org.embulk.base.restclient.record;
+package org.embulk.base.restclient.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.embulk.base.restclient.record.ValueLocator;
 
 public abstract class JacksonValueLocator
         extends ValueLocator

--- a/src/main/java/org/embulk/base/restclient/jackson/StringJsonParser.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/StringJsonParser.java
@@ -1,4 +1,4 @@
-package org.embulk.base.restclient.json;
+package org.embulk.base.restclient.jackson;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
@@ -26,12 +26,12 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 
 import org.slf4j.Logger;
 
-import org.embulk.base.restclient.JacksonServiceResponseMapper;
 import org.embulk.base.restclient.RestClientInputPluginDelegate;
 import org.embulk.base.restclient.RestClientInputTaskBase;
-import org.embulk.base.restclient.json.StringJsonParser;
-import org.embulk.base.restclient.record.JacksonServiceRecord;
-import org.embulk.base.restclient.record.JacksonValueLocator;
+import org.embulk.base.restclient.jackson.JacksonServiceRecord;
+import org.embulk.base.restclient.jackson.JacksonServiceResponseMapper;
+import org.embulk.base.restclient.jackson.JacksonValueLocator;
+import org.embulk.base.restclient.jackson.StringJsonParser;
 import org.embulk.base.restclient.record.RecordImporter;
 import org.embulk.base.restclient.request.RetryHelper;
 import org.embulk.base.restclient.request.SingleRequester;


### PR DESCRIPTION
@muga The last PR (expected) to get the library ready! :)

Moving all Jackson dependencies into one Java package. I guess it will help developers when they need to extend the library for non-JSON APIs.

What do you think?