### PR TITLE
Remove |TaskReportBuildable|, and return |TaskReport| from |ingestServiceData|.

### DIFF
--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginBase.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginBase.java
@@ -26,7 +26,6 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase>
                                         ConfigDiffBuildable<T> configDiffBuilder,
                                         ServiceDataIngestable<T> serviceDataIngester,
                                         ServiceResponseMapperBuildable<T> serviceResponseMapperBuilder,
-                                        TaskReportBuildable<T> taskReportBuilder,
                                         TaskValidatable<T> taskValidator,
                                         int taskCount)
     {
@@ -35,7 +34,6 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase>
               configDiffBuilder,
               serviceDataIngester,
               serviceResponseMapperBuilder,
-              taskReportBuilder,
               taskValidator,
               taskCount);
     }
@@ -44,7 +42,7 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase>
                                         RestClientInputPluginDelegate<T> delegate,
                                         int taskCount)
     {
-        super(taskClass, delegate, delegate, delegate, delegate, delegate, delegate, taskCount);
+        super(taskClass, delegate, delegate, delegate, delegate, delegate, taskCount);
     }
 
     @Override

--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginDelegate.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginDelegate.java
@@ -7,7 +7,6 @@ public interface RestClientInputPluginDelegate<T extends RestClientInputTaskBase
                 ConfigDiffBuildable<T>,
                 ServiceDataIngestable<T>,
                 ServiceResponseMapperBuildable<T>,
-                TaskReportBuildable<T>,
                 TaskValidatable<T>
 {
 }

--- a/src/main/java/org/embulk/base/restclient/ServiceDataIngestable.java
+++ b/src/main/java/org/embulk/base/restclient/ServiceDataIngestable.java
@@ -1,5 +1,6 @@
 package org.embulk.base.restclient;
 
+import org.embulk.config.TaskReport;
 import org.embulk.spi.PageBuilder;
 
 import org.embulk.base.restclient.record.RecordImporter;
@@ -7,5 +8,5 @@ import org.embulk.base.restclient.request.RetryHelper;
 
 public interface ServiceDataIngestable<T extends RestClientInputTaskBase>
 {
-    public void ingestServiceData(T task, RetryHelper retryHelper, RecordImporter recordImporter, int taskCount, PageBuilder pageBuilder);
+    public TaskReport ingestServiceData(T task, RetryHelper retryHelper, RecordImporter recordImporter, int taskCount, PageBuilder pageBuilder);
 }

--- a/src/main/java/org/embulk/base/restclient/TaskReportBuildable.java
+++ b/src/main/java/org/embulk/base/restclient/TaskReportBuildable.java
@@ -1,8 +1,0 @@
-package org.embulk.base.restclient;
-
-import org.embulk.config.TaskReport;
-
-public interface TaskReportBuildable<T extends RestClientTaskBase>
-{
-    TaskReport buildTaskReport(T task);
-}

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
@@ -126,11 +126,11 @@ public class ShopifyInputPluginDelegate
     private static final int PAGE_LIMIT = 250;
 
     @Override  // Overridden from |ServiceDataIngestable|
-    public void ingestServiceData(final PluginTask task,
-                                  RetryHelper retryHelper,
-                                  RecordImporter recordImporter,
-                                  int taskCount,
-                                  PageBuilder pageBuilder)
+    public TaskReport ingestServiceData(final PluginTask task,
+                                        RetryHelper retryHelper,
+                                        RecordImporter recordImporter,
+                                        int taskCount,
+                                        PageBuilder pageBuilder)
     {
         int pageIndex = 1;
         while (true) {
@@ -160,6 +160,7 @@ public class ShopifyInputPluginDelegate
 
             pageIndex++;
         }
+        return Exec.newTaskReport();
     }
 
     private ArrayNode extractArrayField(String content)
@@ -206,12 +207,6 @@ public class ShopifyInputPluginDelegate
                     return status / 100 != 4;  // Retry unless 4xx except for 429.
                 }
             });
-    }
-
-    @Override  // Overridden from |TaskReportBuildable|
-    public TaskReport buildTaskReport(PluginTask task)
-    {
-        return Exec.newTaskReport();
     }
 
     @Override  // Overridden from |ClientCreatable|

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
@@ -129,7 +129,7 @@ public class ShopifyInputPluginDelegate
     public TaskReport ingestServiceData(final PluginTask task,
                                         RetryHelper retryHelper,
                                         RecordImporter recordImporter,
-                                        int taskCount,
+                                        int taskIndex,
                                         PageBuilder pageBuilder)
     {
         int pageIndex = 1;


### PR DESCRIPTION
@muga Sorry, found that `TaskReportBuildable` was useless just from `Task`. Changed `ingestServiceData` to return `TaskReport` by itself, and removed `TaskReportBuildable`.