### PR TITLE
Configure retries out of base classes.

### DIFF
--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginBase.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginBase.java
@@ -33,6 +33,7 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase>
     protected RestClientInputPluginBase(Class<T> taskClass,
                                         ClientCreatable<T> clientCreator,
                                         ConfigDiffBuildable<T> configDiffBuilder,
+                                        RetryConfigurable<T> retryConfigurator,
                                         ServiceDataIngestable<T> serviceDataIngester,
                                         ServiceResponseMapperBuildable<T> serviceResponseMapperBuilder,
                                         TaskValidatable<T> taskValidator,
@@ -41,6 +42,7 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase>
         super(taskClass,
               clientCreator,
               configDiffBuilder,
+              retryConfigurator,
               serviceDataIngester,
               serviceResponseMapperBuilder,
               taskValidator,
@@ -55,6 +57,7 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase>
     protected RestClientInputPluginBase(Class<T> taskClass,
                                         ClientCreatable<T> clientCreator,
                                         ConfigDiffBuildable<T> configDiffBuilder,
+                                        RetryConfigurable<T> retryConfigurator,
                                         ServiceDataIngestable<T> serviceDataIngester,
                                         ServiceResponseMapperBuildable<T> serviceResponseMapperBuilder,
                                         TaskValidatable<T> taskValidator)
@@ -62,6 +65,7 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase>
         super(taskClass,
               clientCreator,
               configDiffBuilder,
+              retryConfigurator,
               serviceDataIngester,
               serviceResponseMapperBuilder,
               taskValidator,
@@ -81,7 +85,7 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase>
                                         RestClientInputPluginDelegate<T> delegate,
                                         int taskCount)
     {
-        super(taskClass, delegate, delegate, delegate, delegate, delegate, taskCount);
+        super(taskClass, delegate, delegate, delegate, delegate, delegate, delegate, taskCount);
     }
 
     /**
@@ -92,7 +96,7 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase>
     protected RestClientInputPluginBase(Class<T> taskClass,
                                         RestClientInputPluginDelegate<T> delegate)
     {
-        super(taskClass, delegate, delegate, delegate, delegate, delegate, 1);
+        super(taskClass, delegate, delegate, delegate, delegate, delegate, delegate, 1);
     }
 
     @Override

--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginDelegate.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginDelegate.java
@@ -3,6 +3,7 @@ package org.embulk.base.restclient;
 public interface RestClientInputPluginDelegate<T extends RestClientInputTaskBase>
         extends ClientCreatable<T>,
                 ConfigDiffBuildable<T>,
+                RetryConfigurable<T>,
                 ServiceDataIngestable<T>,
                 ServiceResponseMapperBuildable<T>,
                 TaskValidatable<T>

--- a/src/main/java/org/embulk/base/restclient/RestClientInputTaskBase.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputTaskBase.java
@@ -6,19 +6,6 @@ import org.embulk.config.ConfigDefault;
 public interface RestClientInputTaskBase
         extends RestClientTaskBase
 {
-    // client retry setting
-    @Config("retry_limit")
-    @ConfigDefault("7")
-    public int getRetryLimit();
-
-    @Config("initial_retry_wait")
-    @ConfigDefault("1000")
-    public int getInitialRetryWait();
-
-    @Config("max_retry_wait")
-    @ConfigDefault("60000")
-    public int getMaxRetryWait();
-
     // incremental data loading setting
     @Config("incremental")
     @ConfigDefault("true")

--- a/src/main/java/org/embulk/base/restclient/RetryConfigurable.java
+++ b/src/main/java/org/embulk/base/restclient/RetryConfigurable.java
@@ -1,0 +1,8 @@
+package org.embulk.base.restclient;
+
+public interface RetryConfigurable<T extends RestClientTaskBase>
+{
+    public int configureMaximumRetries(T task);
+    public int configureInitialRetryIntervalMillis(T task);
+    public int configureMaximumRetryIntervalMillis(T task);
+}

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
@@ -44,6 +44,19 @@ public class ShopifyInputPluginDelegate
     public interface PluginTask
             extends RestClientInputTaskBase
     {
+        // client retry setting
+        @Config("retry_limit")
+        @ConfigDefault("7")
+        public int getRetryLimit();
+
+        @Config("initial_retry_wait")
+        @ConfigDefault("1000")
+        public int getInitialRetryWait();
+
+        @Config("max_retry_wait")
+        @ConfigDefault("60000")
+        public int getMaxRetryWait();
+
         // An example required configuration
 
         // client timeout and connection setting: for RESTEasy
@@ -221,6 +234,24 @@ public class ShopifyInputPluginDelegate
             .connectionPoolSize(task.getConnectionPoolSize())
             .build();
         return client;
+    }
+
+    @Override  // Overridden from |RetryConfigurable|
+    public int configureMaximumRetries(PluginTask task)
+    {
+        return task.getRetryLimit();
+    }
+
+    @Override  // Overridden from |RetryConfigurable|
+    public int configureInitialRetryIntervalMillis(PluginTask task)
+    {
+        return task.getInitialRetryWait();
+    }
+
+    @Override  // Overridden from |RetryConfigurable|
+    public int configureMaximumRetryIntervalMillis(PluginTask task)
+    {
+        return task.getMaxRetryWait();
     }
 
     private final Logger logger = Exec.getLogger(ShopifyInputPluginDelegate.class);


### PR DESCRIPTION
@muga Trying to remove config parameters which are unconditionally in the base `Task` class. This PR removes retry-related parameters.

We may encourage using common parameter names by preparing some default implementations with Java 8 interface w/ implementation.