### PR TITLE
Build |ConfigDiff| without seeing |incremental|.

### DIFF
--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginBaseUnsafe.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginBaseUnsafe.java
@@ -100,11 +100,7 @@ public class RestClientInputPluginBaseUnsafe<T extends RestClientInputTaskBase>
     {
         T task = taskSource.loadTask(this.taskClass);
         List<TaskReport> taskReports = control.run(taskSource, schema, taskCount);
-        if (task.getIncremental()) {
-            return this.configDiffBuilder.buildConfigDiff(task, schema, taskCount, taskReports);
-        } else {
-            return Exec.newConfigDiff();
-        }
+        return this.configDiffBuilder.buildConfigDiff(task, schema, taskCount, taskReports);
     }
 
     @Override

--- a/src/main/java/org/embulk/base/restclient/RestClientInputTaskBase.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputTaskBase.java
@@ -1,13 +1,6 @@
 package org.embulk.base.restclient;
 
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
-
 public interface RestClientInputTaskBase
         extends RestClientTaskBase
 {
-    // incremental data loading setting
-    @Config("incremental")
-    @ConfigDefault("true")
-    public boolean getIncremental();
 }


### PR DESCRIPTION
The judge of `incremental` would be done in each plugin implementation.

@muga Can you PTAL? It's replacing #45.