### PR TITLE
Update embulk-input-example to use embulk-base-restclient 0.2.1.

### DIFF
--- a/embulk-input-example/build.gradle
+++ b/embulk-input-example/build.gradle
@@ -17,7 +17,7 @@ configurations {
     provided
 }
 
-version = "0.1.0"
+version = "0.1.1"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
@@ -25,7 +25,7 @@ targetCompatibility = 1.7
 dependencies {
     compile  "org.embulk:embulk-core:0.8.15"
     provided "org.embulk:embulk-core:0.8.15"
-    compile  "org.embulk.base.restclient:embulk-base-restclient:0.2.0"
+    compile  "org.embulk.base.restclient:embulk-base-restclient:0.2.1"
     compile  "org.glassfish.jersey.core:jersey-client:2.25.1"
 
     testCompile "junit:junit:4.+"


### PR DESCRIPTION
@muga After releasing v0.2.1, the example will be updated as well.