### PR TITLE
Make |*ValueImporter| to throw Exceptions which are easier to investigate.

### DIFF
--- a/src/main/java/org/embulk/base/restclient/record/values/BooleanValueImporter.java
+++ b/src/main/java/org/embulk/base/restclient/record/values/BooleanValueImporter.java
@@ -1,6 +1,7 @@
 package org.embulk.base.restclient.record.values;
 
 import org.embulk.spi.Column;
+import org.embulk.spi.DataException;
 import org.embulk.spi.PageBuilder;
 
 import org.embulk.base.restclient.record.ServiceRecord;
@@ -19,12 +20,16 @@ public class BooleanValueImporter
     @Override
     public void findAndImportValue(ServiceRecord record, PageBuilder pageBuilder)
     {
-        ServiceValue value = findValue(record);
-        if (value == null || value.isNull()) {
-            pageBuilder.setNull(getColumnToImport());
-        }
-        else {
-            pageBuilder.setBoolean(getColumnToImport(), value.booleanValue());
+        try {
+            ServiceValue value = findValue(record);
+            if (value == null || value.isNull()) {
+                pageBuilder.setNull(getColumnToImport());
+            }
+            else {
+                pageBuilder.setBoolean(getColumnToImport(), value.booleanValue());
+            }
+        } catch (Exception ex) {
+            throw new DataException("Failed to import a value for column: " + getColumnToImport().getName() + " (" + getColumnToImport().getType().getName() + ")", ex);
         }
     }
 }

--- a/src/main/java/org/embulk/base/restclient/record/values/DoubleValueImporter.java
+++ b/src/main/java/org/embulk/base/restclient/record/values/DoubleValueImporter.java
@@ -1,6 +1,7 @@
 package org.embulk.base.restclient.record.values;
 
 import org.embulk.spi.Column;
+import org.embulk.spi.DataException;
 import org.embulk.spi.PageBuilder;
 
 import org.embulk.base.restclient.record.ServiceRecord;
@@ -19,12 +20,16 @@ public class DoubleValueImporter
     @Override
     public void findAndImportValue(ServiceRecord record, PageBuilder pageBuilder)
     {
-        ServiceValue value = findValue(record);
-        if (value == null || value.isNull()) {
-            pageBuilder.setNull(getColumnToImport());
-        }
-        else {
-            pageBuilder.setDouble(getColumnToImport(), value.doubleValue());
+        try {
+            ServiceValue value = findValue(record);
+            if (value == null || value.isNull()) {
+                pageBuilder.setNull(getColumnToImport());
+            }
+            else {
+                pageBuilder.setDouble(getColumnToImport(), value.doubleValue());
+            }
+        } catch (Exception ex) {
+            throw new DataException("Failed to import a value for column: " + getColumnToImport().getName() + " (" + getColumnToImport().getType().getName() + ")", ex);
         }
     }
 }

--- a/src/main/java/org/embulk/base/restclient/record/values/JsonValueImporter.java
+++ b/src/main/java/org/embulk/base/restclient/record/values/JsonValueImporter.java
@@ -1,6 +1,7 @@
 package org.embulk.base.restclient.record.values;
 
 import org.embulk.spi.Column;
+import org.embulk.spi.DataException;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.json.JsonParser;
 
@@ -21,12 +22,16 @@ public class JsonValueImporter
     @Override
     public void findAndImportValue(ServiceRecord record, PageBuilder pageBuilder)
     {
-        ServiceValue value = findValue(record);
-        if (value == null || value.isNull()) {
-            pageBuilder.setNull(getColumnToImport());
-        }
-        else {
-            pageBuilder.setJson(getColumnToImport(), value.jsonValue(jsonParser));
+        try {
+            ServiceValue value = findValue(record);
+            if (value == null || value.isNull()) {
+                pageBuilder.setNull(getColumnToImport());
+            }
+            else {
+                pageBuilder.setJson(getColumnToImport(), value.jsonValue(jsonParser));
+            }
+        } catch (Exception ex) {
+            throw new DataException("Failed to import a value for column: " + getColumnToImport().getName() + " (" + getColumnToImport().getType().getName() + ")", ex);
         }
     }
 

--- a/src/main/java/org/embulk/base/restclient/record/values/LongValueImporter.java
+++ b/src/main/java/org/embulk/base/restclient/record/values/LongValueImporter.java
@@ -1,6 +1,7 @@
 package org.embulk.base.restclient.record.values;
 
 import org.embulk.spi.Column;
+import org.embulk.spi.DataException;
 import org.embulk.spi.PageBuilder;
 
 import org.embulk.base.restclient.record.ServiceRecord;
@@ -19,12 +20,16 @@ public class LongValueImporter
     @Override
     public void findAndImportValue(ServiceRecord record, PageBuilder pageBuilder)
     {
-        ServiceValue value = findValue(record);
-        if (value == null || value.isNull()) {
-            pageBuilder.setNull(getColumnToImport());
-        }
-        else {
-            pageBuilder.setLong(getColumnToImport(), value.longValue());
+        try {
+            ServiceValue value = findValue(record);
+            if (value == null || value.isNull()) {
+                pageBuilder.setNull(getColumnToImport());
+            }
+            else {
+                pageBuilder.setLong(getColumnToImport(), value.longValue());
+            }
+        } catch (Exception ex) {
+            throw new DataException("Failed to import a value for column: " + getColumnToImport().getName() + " (" + getColumnToImport().getType().getName() + ")", ex);
         }
     }
 }

--- a/src/main/java/org/embulk/base/restclient/record/values/StringValueImporter.java
+++ b/src/main/java/org/embulk/base/restclient/record/values/StringValueImporter.java
@@ -1,6 +1,7 @@
 package org.embulk.base.restclient.record.values;
 
 import org.embulk.spi.Column;
+import org.embulk.spi.DataException;
 import org.embulk.spi.PageBuilder;
 
 import org.embulk.base.restclient.record.ServiceRecord;
@@ -19,12 +20,16 @@ public class StringValueImporter
     @Override
     public void findAndImportValue(ServiceRecord record, PageBuilder pageBuilder)
     {
-        ServiceValue value = findValue(record);
-        if (value == null || value.isNull()) {
-            pageBuilder.setNull(getColumnToImport());
-        }
-        else {
-            pageBuilder.setString(getColumnToImport(), value.stringValue());
+        try {
+            ServiceValue value = findValue(record);
+            if (value == null || value.isNull()) {
+                pageBuilder.setNull(getColumnToImport());
+            }
+            else {
+                pageBuilder.setString(getColumnToImport(), value.stringValue());
+            }
+        } catch (Exception ex) {
+            throw new DataException("Failed to import a value for column: " + getColumnToImport().getName() + " (" + getColumnToImport().getType().getName() + ")", ex);
         }
     }
 }

--- a/src/main/java/org/embulk/base/restclient/record/values/TimestampValueImporter.java
+++ b/src/main/java/org/embulk/base/restclient/record/values/TimestampValueImporter.java
@@ -1,6 +1,7 @@
 package org.embulk.base.restclient.record.values;
 
 import org.embulk.spi.Column;
+import org.embulk.spi.DataException;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.TimestampParser;
 
@@ -21,12 +22,16 @@ public class TimestampValueImporter
     @Override
     public void findAndImportValue(ServiceRecord record, PageBuilder pageBuilder)
     {
-        ServiceValue value = findValue(record);
-        if (value == null || value.isNull()) {
-            pageBuilder.setNull(getColumnToImport());
-        }
-        else {
-            pageBuilder.setTimestamp(getColumnToImport(), value.timestampValue(timestampParser));
+        try {
+            ServiceValue value = findValue(record);
+            if (value == null || value.isNull()) {
+                pageBuilder.setNull(getColumnToImport());
+            }
+            else {
+                pageBuilder.setTimestamp(getColumnToImport(), value.timestampValue(timestampParser));
+            }
+        } catch (Exception ex) {
+            throw new DataException("Failed to import a value for column: " + getColumnToImport().getName() + " (" + getColumnToImport().getType().getName() + ")", ex);
         }
     }
 


### PR DESCRIPTION
@muga Making `ValueImporter` classes to show the column name where the `ValueImporter` fails.

One additional idea is to include the value in the message. It may be, however, security-incompliant because it prints customer's data into logs. Can I have your thoughts?