### PR TITLE
Set NullNode when JsonNode value in record is null

### DIFF
--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceValue.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceValue.java
@@ -2,6 +2,7 @@ package org.embulk.base.restclient.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import com.fasterxml.jackson.databind.node.NullNode;
 import org.embulk.base.restclient.record.ServiceValue;
 
 /**
@@ -31,13 +32,17 @@ public class JacksonServiceValue
 {
     public JacksonServiceValue(JsonNode value)
     {
-        this.value = value;
+        if (value == null) {
+            this.value = NullNode.getInstance();
+        } else {
+            this.value = value;
+        }
     }
 
     @Override
     public boolean isNull()
     {
-        return value == null || value.isNull();
+        return value.isNull();
     }
 
     @Override

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceValue.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceValue.java
@@ -37,7 +37,7 @@ public class JacksonServiceValue
     @Override
     public boolean isNull()
     {
-        return value.isNull();
+        return value == null || value.isNull();
     }
 
     @Override


### PR DESCRIPTION
I got following failure and fixed it.
This failure happens because Web API doesn't returns record itself when its value is null.

### Models
```java
private JacksonServiceResponseMapper model = JacksonServiceResponseMapper.builder()
            .add("id", Types.STRING)
            .add("column_abcdefg", Types.BOOLEAN)
            .build();
```

### API response
```sh
{
  "id": "aaa_1234567"
   # API doesn't returns 'column_abcdefg' record itself when its value is null
}
```

### Stacktrace

```
Caused by: org.embulk.spi.DataException: Failed to import a value for column: column_abcdefg (boolean)
	at org.embulk.base.restclient.record.values.BooleanValueImporter.findAndImportValue(BooleanValueImporter.java:40)
	at org.embulk.base.restclient.record.RecordImporter.importRecord(RecordImporter.java:17)
	at org.embulk.input.xxxxx.xxxxxInputPluginDelegate.ingestServiceData(xxxxxInputPluginDelegate.java:389)
	at org.embulk.input.xxxxx.xxxxxInputPluginDelegate.ingestServiceData(xxxxxInputPluginDelegate.java:65)
	at org.embulk.base.restclient.RestClientInputPluginBaseUnsafe.run(RestClientInputPluginBaseUnsafe.java:125)
	at org.embulk.base.restclient.RestClientInputPluginBase.run(RestClientInputPluginBase.java:123)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.runInputTask(LocalExecutorPlugin.java:294)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.access$000(LocalExecutorPlugin.java:212)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:257)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:253)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NullPointerException
	at org.embulk.base.restclient.jackson.JacksonServiceValue.isNull(JacksonServiceValue.java:41)
	at org.embulk.base.restclient.record.values.BooleanValueImporter.findAndImportValue(BooleanValueImporter.java:29)
	... 13 more
```

I found that `BooleanValueImport.findAndImportValue()` has null check logic, but always returns `false` and `JacksonServiceValue.isNull()` throws NullPointerException.

```java
// this value type is 'ServiceValue'
// 'value==null' always returns false
// Then 'value.isNull()' throws NullPointerException
if (value == null || value.isNull()) {
    pageBuilder.setNull(getColumnToImport());
}
```
[BooleanValueImport.java](https://github.com/embulk/embulk-base-restclient/blob/master/src/main/java/org/embulk/base/restclient/record/values/BooleanValueImporter.java#L25)

So I added additional null check logic to `JacksonServiceValue.isNull()` method.