### PR TITLE
Rename |JacksonFlatValueLocator| to |JacksonTopLevelValueLocator|

### DIFF
--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceResponseMapper.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceResponseMapper.java
@@ -72,7 +72,7 @@ public final class JacksonServiceResponseMapper
         {
             mapBuilder.put(new Column(index++, embulkColumnName, embulkColumnType),
                            new ColumnOptions<JacksonValueLocator>(
-                               new JacksonFlatValueLocator(embulkColumnName)));
+                               new JacksonTopLevelValueLocator(embulkColumnName)));
             return this;
         }
 
@@ -83,7 +83,7 @@ public final class JacksonServiceResponseMapper
         {
             mapBuilder.put(new Column(index++, embulkColumnName, embulkColumnType),
                            new ColumnOptions<JacksonValueLocator>(
-                               new JacksonFlatValueLocator(embulkColumnName),
+                               new JacksonTopLevelValueLocator(embulkColumnName),
                                embulkColumnTimestampFormat));
             return this;
         }

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonTopLevelValueLocator.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonTopLevelValueLocator.java
@@ -3,10 +3,10 @@ package org.embulk.base.restclient.jackson;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-public class JacksonFlatValueLocator
+public class JacksonTopLevelValueLocator
         extends JacksonValueLocator
 {
-    public JacksonFlatValueLocator(String name)
+    public JacksonTopLevelValueLocator(String name)
     {
         this.name = name;
     }


### PR DESCRIPTION
@muga I was forgetting this one. Renaming `JacksonFlatValueLocator` to `JacksonTopLevelValueLocator` since "flat" may be confusing and hard to understand.