### PR TITLE
Add more |EmbulkValueScope| implementations for Jackson, and support placing values with JSON Pointers.

### DIFF
--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceRequestMapper.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceRequestMapper.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 
 import org.embulk.base.restclient.ServiceRequestMapper;
+import org.embulk.base.restclient.jackson.scope.JacksonNewObjectScope;
 import org.embulk.base.restclient.record.EmbulkValueScope;
 import org.embulk.base.restclient.record.RecordExporter;
 import org.embulk.base.restclient.record.ValueExporter;
@@ -44,6 +45,15 @@ public final class JacksonServiceRequestMapper
         private Builder()
         {
             this.mapBuilder = ImmutableListMultimap.builder();
+        }
+
+        public synchronized JacksonServiceRequestMapper.Builder addNewObject(
+                JacksonValueLocator valueLocator)
+        {
+            mapBuilder.put(new JacksonNewObjectScope(),
+                           new ColumnOptions<JacksonValueLocator>(valueLocator));
+            return this;
+
         }
 
         public synchronized JacksonServiceRequestMapper.Builder add(

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonArrayScopeBase.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonArrayScopeBase.java
@@ -1,0 +1,19 @@
+package org.embulk.base.restclient.jackson.scope;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import org.embulk.base.restclient.jackson.JacksonServiceValue;
+import org.embulk.base.restclient.record.EmbulkValueScope;
+import org.embulk.base.restclient.record.SinglePageRecordReader;
+
+public abstract class JacksonArrayScopeBase
+        extends EmbulkValueScope
+{
+    public abstract ArrayNode scopeArray(SinglePageRecordReader singlePageRecordReader);
+
+    @Override
+    public final JacksonServiceValue scopeEmbulkValues(SinglePageRecordReader singlePageRecordReader)
+    {
+        return new JacksonServiceValue(this.scopeArray(singlePageRecordReader));
+    }
+}

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonDirectIntegerScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonDirectIntegerScope.java
@@ -1,0 +1,25 @@
+package org.embulk.base.restclient.jackson.scope;
+
+import org.embulk.spi.Column;
+import org.embulk.spi.Schema;
+
+import org.embulk.base.restclient.record.SinglePageRecordReader;
+
+public class JacksonDirectIntegerScope
+        extends JacksonIntegerScopeBase
+{
+    public JacksonDirectIntegerScope(String embulkColumnName)
+    {
+        this.embulkColumnName = embulkColumnName;
+    }
+
+    @Override
+    public long scopeInteger(SinglePageRecordReader singlePageRecordReader)
+    {
+        Schema embulkSchema = singlePageRecordReader.getSchema();
+        Column column = cacheSingleColumn(embulkSchema, this.embulkColumnName);
+        return singlePageRecordReader.getLong(column);
+    }
+
+    private final String embulkColumnName;
+}

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonDirectStringScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonDirectStringScope.java
@@ -1,20 +1,20 @@
-package org.embulk.base.restclient.jackson;
+package org.embulk.base.restclient.jackson.scope;
 
 import org.embulk.spi.Column;
 import org.embulk.spi.Schema;
 
 import org.embulk.base.restclient.record.SinglePageRecordReader;
 
-public class JacksonStraightStringValueScope
-        extends JacksonStringValueScope
+public class JacksonDirectStringScope
+        extends JacksonStringScopeBase
 {
-    public JacksonStraightStringValueScope(String embulkColumnName)
+    public JacksonDirectStringScope(String embulkColumnName)
     {
         this.embulkColumnName = embulkColumnName;
     }
 
     @Override
-    public String scopeStringValue(SinglePageRecordReader singlePageRecordReader)
+    public String scopeString(SinglePageRecordReader singlePageRecordReader)
     {
         Schema embulkSchema = singlePageRecordReader.getSchema();
         Column column = cacheSingleColumn(embulkSchema, this.embulkColumnName);

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonImmediateIntegerScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonImmediateIntegerScope.java
@@ -1,0 +1,20 @@
+package org.embulk.base.restclient.jackson.scope;
+
+import org.embulk.base.restclient.record.SinglePageRecordReader;
+
+public class JacksonImmediateIntegerScope
+        extends JacksonIntegerScopeBase
+{
+    public JacksonImmediateIntegerScope(long immediateInteger)
+    {
+        this.immediateInteger = immediateInteger;
+    }
+
+    @Override
+    public long scopeInteger(SinglePageRecordReader singlePageRecordReader)
+    {
+        return this.immediateInteger;
+    }
+
+    private final long immediateInteger;
+}

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonImmediateStringScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonImmediateStringScope.java
@@ -1,0 +1,20 @@
+package org.embulk.base.restclient.jackson.scope;
+
+import org.embulk.base.restclient.record.SinglePageRecordReader;
+
+public class JacksonImmediateStringScope
+        extends JacksonStringScopeBase
+{
+    public JacksonImmediateStringScope(String immediateString)
+    {
+        this.immediateString = immediateString;
+    }
+
+    @Override
+    public String scopeString(SinglePageRecordReader singlePageRecordReader)
+    {
+        return this.immediateString;
+    }
+
+    private final String immediateString;
+}

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonIntegerScopeBase.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonIntegerScopeBase.java
@@ -1,18 +1,19 @@
-package org.embulk.base.restclient.jackson;
+package org.embulk.base.restclient.jackson.scope;
 
 import com.fasterxml.jackson.databind.node.LongNode;
 
+import org.embulk.base.restclient.jackson.JacksonServiceValue;
 import org.embulk.base.restclient.record.EmbulkValueScope;
 import org.embulk.base.restclient.record.SinglePageRecordReader;
 
-public abstract class JacksonIntegerValueScope
+public abstract class JacksonIntegerScopeBase
         extends EmbulkValueScope
 {
-    public abstract long scopeIntegerValue(SinglePageRecordReader singlePageRecordReader);
+    public abstract long scopeInteger(SinglePageRecordReader singlePageRecordReader);
 
     @Override
     public final JacksonServiceValue scopeEmbulkValues(SinglePageRecordReader singlePageRecordReader)
     {
-        return new JacksonServiceValue(new LongNode(this.scopeIntegerValue(singlePageRecordReader)));
+        return new JacksonServiceValue(new LongNode(this.scopeInteger(singlePageRecordReader)));
     }
 }

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonNewArrayScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonNewArrayScope.java
@@ -1,0 +1,16 @@
+package org.embulk.base.restclient.jackson.scope;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+import org.embulk.base.restclient.record.SinglePageRecordReader;
+
+public class JacksonNewArrayScope
+        extends JacksonArrayScopeBase
+{
+    @Override
+    public ArrayNode scopeArray(SinglePageRecordReader singlePageRecordReader)
+    {
+        return JsonNodeFactory.instance.arrayNode();
+    }
+}

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonNewObjectScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonNewObjectScope.java
@@ -1,0 +1,16 @@
+package org.embulk.base.restclient.jackson.scope;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.embulk.base.restclient.record.SinglePageRecordReader;
+
+public class JacksonNewObjectScope
+        extends JacksonObjectScopeBase
+{
+    @Override
+    public ObjectNode scopeObject(SinglePageRecordReader singlePageRecordReader)
+    {
+        return JsonNodeFactory.instance.objectNode();
+    }
+}

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonObjectScopeBase.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonObjectScopeBase.java
@@ -1,0 +1,19 @@
+package org.embulk.base.restclient.jackson.scope;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.embulk.base.restclient.jackson.JacksonServiceValue;
+import org.embulk.base.restclient.record.EmbulkValueScope;
+import org.embulk.base.restclient.record.SinglePageRecordReader;
+
+public abstract class JacksonObjectScopeBase
+        extends EmbulkValueScope
+{
+    public abstract ObjectNode scopeObject(SinglePageRecordReader singlePageRecordReader);
+
+    @Override
+    public final JacksonServiceValue scopeEmbulkValues(SinglePageRecordReader singlePageRecordReader)
+    {
+        return new JacksonServiceValue(this.scopeObject(singlePageRecordReader));
+    }
+}

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonStringScopeBase.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonStringScopeBase.java
@@ -1,18 +1,19 @@
-package org.embulk.base.restclient.jackson;
+package org.embulk.base.restclient.jackson.scope;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 
+import org.embulk.base.restclient.jackson.JacksonServiceValue;
 import org.embulk.base.restclient.record.EmbulkValueScope;
 import org.embulk.base.restclient.record.SinglePageRecordReader;
 
-public abstract class JacksonStringValueScope
+public abstract class JacksonStringScopeBase
         extends EmbulkValueScope
 {
-    public abstract String scopeStringValue(SinglePageRecordReader singlePageRecordReader);
+    public abstract String scopeString(SinglePageRecordReader singlePageRecordReader);
 
     @Override
     public final JacksonServiceValue scopeEmbulkValues(SinglePageRecordReader singlePageRecordReader)
     {
-        return new JacksonServiceValue(new TextNode(this.scopeStringValue(singlePageRecordReader)));
+        return new JacksonServiceValue(new TextNode(this.scopeString(singlePageRecordReader)));
     }
 }


### PR DESCRIPTION
@muga @sakama Adding more `EmbulkValueScope` implementations to support more flexible outputs.

Will release v0.4.0 after this PR is merged.

See example at :
https://github.com/embulk/embulk-base-restclient/compare/more-scopes?expand=1#diff-0a75a6c3d5b4fa9fe7af36e6d55832d3R69

This `JacksonServiceRequestMapper` outputs a JSON as below:

```
{
  "id":12,
  "name":"someone",
  "dict":{
    "sub1":{
      "sub2":{
        "bar":"hoge"
      },
    "foo":"fuga"}
  }
}
```