### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Release 0.4.0 - 2017-03-06
+
+* [update] Add base classes for output plugins.
+* [incompatibility] `validateTask` is renamed to `validateInputTask`.
+
 Release 0.3.0 - 2017-02-28
 
 * [update] Split `RetryHelper` into separate libraries so that developers can use their own HTTP client.

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,6 @@ plugins {
     //id "jacoco"
 }
 
-group = 'org.embulk.base.restclient'
-version = '0.3.0'
-
 subprojects {
     apply plugin: 'maven'
     apply plugin: 'maven-publish'
@@ -22,6 +19,9 @@ subprojects {
 }
 
 allprojects {
+    group = 'org.embulk.base.restclient'
+    version = '0.4.0'
+
     repositories {
         mavenCentral()
         jcenter()

--- a/embulk-input-example/build.gradle
+++ b/embulk-input-example/build.gradle
@@ -1,8 +1,5 @@
 import com.github.jrubygradle.JRubyExec
 
-group = 'org.embulk.base.restclient'
-version = "0.1.1"
-
 dependencies {
     compile     project(':')
     compile     project(':embulk-util-retryhelper-jaxrs')

--- a/embulk-input-example_jetty93/build.gradle
+++ b/embulk-input-example_jetty93/build.gradle
@@ -1,8 +1,5 @@
 import com.github.jrubygradle.JRubyExec
 
-group = 'org.embulk.base.restclient'
-version = "0.1.0"
-
 dependencies {
     compile     project(':')
     compile     project(':embulk-util-retryhelper-jetty93')

--- a/embulk-output-example/build.gradle
+++ b/embulk-output-example/build.gradle
@@ -1,8 +1,5 @@
 import com.github.jrubygradle.JRubyExec
 
-group = 'org.embulk.base.restclient'
-version = "0.1.1"
-
 dependencies {
     compile     project(':')
     compile     project(':embulk-util-retryhelper-jaxrs')

--- a/embulk-util-retryhelper-jaxrs/build.gradle
+++ b/embulk-util-retryhelper-jaxrs/build.gradle
@@ -1,6 +1,3 @@
-group = 'org.embulk.base.restclient'
-version = '0.1.0'
-
 dependencies {
     compile     'javax.ws.rs:javax.ws.rs-api:2.0.1'
 }
@@ -18,7 +15,7 @@ bintray {
         userOrg = 'embulk-base-restclient'
         repo = 'maven'
         name = project.name
-        desc = 'Base class library to access RESTful services'
+        desc = 'Utility library to retry HTTP requests through JAX-RS 2.0 Client with Embulk RetryExecutor'
         websiteUrl = 'https://github.com/embulk/embulk-base-restclient/tree/master/embulk-util-retryhelper-jaxrs'
         issueTrackerUrl = 'https://github.com/embulk/embulk-base-restclient/issues'
         vcsUrl = 'https://github.com/embulk/embulk-base-restclient.git'

--- a/embulk-util-retryhelper-jetty92/build.gradle
+++ b/embulk-util-retryhelper-jetty92/build.gradle
@@ -1,6 +1,3 @@
-group = 'org.embulk.base.restclient'
-version = '0.1.0'
-
 dependencies {
     compile     'org.eclipse.jetty:jetty-client:9.2.14.v20151106'
 }
@@ -18,7 +15,7 @@ bintray {
         userOrg = 'embulk-base-restclient'
         repo = 'maven'
         name = project.name
-        desc = 'Base class library to access RESTful services'
+        desc = 'Utility library to retry HTTP requests through Jetty 9.2 client with Embulk RetryExecutor'
         websiteUrl = 'https://github.com/embulk/embulk-base-restclient/tree/master/embulk-util-retryhelper-jetty92'
         issueTrackerUrl = 'https://github.com/embulk/embulk-base-restclient/issues'
         vcsUrl = 'https://github.com/embulk/embulk-base-restclient.git'

--- a/embulk-util-retryhelper-jetty93/build.gradle
+++ b/embulk-util-retryhelper-jetty93/build.gradle
@@ -1,6 +1,3 @@
-group = 'org.embulk.base.restclient'
-version = '0.1.0'
-
 dependencies {
     compile     'org.eclipse.jetty:jetty-client:9.3.16.v20170120'
 }
@@ -18,7 +15,7 @@ bintray {
         userOrg = 'embulk-base-restclient'
         repo = 'maven'
         name = project.name
-        desc = 'Base class library to access RESTful services'
+        desc = 'Utility library to retry HTTP requests through Jetty 9.3 client with Embulk RetryExecutor'
         websiteUrl = 'https://github.com/embulk/embulk-base-restclient/tree/master/embulk-util-retryhelper-jetty93'
         issueTrackerUrl = 'https://github.com/embulk/embulk-base-restclient/issues'
         vcsUrl = 'https://github.com/embulk/embulk-base-restclient.git'


### PR DESCRIPTION
@muga @sakama After #65, releasing v0.4.0 with output plugin support!

From 0.4.0, all util libraries will have the same versions with embulk-base-restclient.