### PR TITLE
Add |JacksonAllInObjectScope| to add all Embulk columns as a JSON Object node.

### DIFF
--- a/embulk-output-example/src/main/java/org/embulk/output/example/ExampleOutputPluginDelegate.java
+++ b/embulk-output-example/src/main/java/org/embulk/output/example/ExampleOutputPluginDelegate.java
@@ -26,6 +26,7 @@ import org.embulk.base.restclient.jackson.JacksonJsonPointerValueLocator;
 import org.embulk.base.restclient.jackson.JacksonServiceRequestMapper;
 import org.embulk.base.restclient.jackson.JacksonTaskReportRecordBuffer;
 import org.embulk.base.restclient.jackson.JacksonTopLevelValueLocator;
+import org.embulk.base.restclient.jackson.scope.JacksonAllInObjectScope;
 import org.embulk.base.restclient.jackson.scope.JacksonDirectIntegerScope;
 import org.embulk.base.restclient.jackson.scope.JacksonDirectStringScope;
 import org.embulk.base.restclient.record.RecordBuffer;
@@ -73,6 +74,7 @@ public class ExampleOutputPluginDelegate
             .addNewObject(new JacksonJsonPointerValueLocator("/dict/sub1/sub2"))
             .add(new JacksonDirectStringScope("foo"), new JacksonJsonPointerValueLocator("/dict/sub1/foo"))
             .add(new JacksonDirectStringScope("bar"), new JacksonJsonPointerValueLocator("/dict/sub1/sub2/bar"))
+            .add(new JacksonAllInObjectScope(), new JacksonTopLevelValueLocator("entire"))
             .build();
     }
 

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceValue.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceValue.java
@@ -60,6 +60,8 @@ public class JacksonServiceValue
     @Override
     public org.msgpack.value.Value jsonValue(org.embulk.spi.json.JsonParser jsonParser)
     {
+        // TODO(dmikurube): Use jackson-datatype-msgpack.
+        // See: https://github.com/embulk/embulk-base-restclient/issues/32
         // Using |JsonNode#toString| instead of |JsonNode#asText| so that an empty JSON value can be parsed.
         // |asText| converts an empty |JsonNode| to "" while |toString| converts to "{}".
         return jsonParser.parse(value.toString());

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
@@ -1,0 +1,85 @@
+package org.embulk.base.restclient.jackson.scope;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.embulk.base.restclient.record.SinglePageRecordReader;
+
+import org.embulk.spi.Column;
+import org.embulk.spi.ColumnVisitor;
+
+public class JacksonAllInObjectScope
+        extends JacksonObjectScopeBase
+{
+    public JacksonAllInObjectScope()
+    {
+        this(null);
+    }
+
+    public JacksonAllInObjectScope(String timestampFormat)
+    {
+        this.timestampFormat = timestampFormat;
+    }
+
+    @Override
+    public ObjectNode scopeObject(final SinglePageRecordReader singlePageRecordReader)
+    {
+        final ObjectNode resultObject = JsonNodeFactory.instance.objectNode();
+
+        singlePageRecordReader.getSchema().visitColumns(new ColumnVisitor()
+            {
+                @Override
+                public void booleanColumn(Column column)
+                {
+                    resultObject.put(column.getName(),
+                                     BooleanNode.valueOf(singlePageRecordReader.getBoolean(column)));
+                }
+
+                @Override
+                public void longColumn(Column column)
+                {
+                    resultObject.put(column.getName(),
+                                     new LongNode(singlePageRecordReader.getLong(column)));
+                }
+
+                @Override
+                public void doubleColumn(Column column)
+                {
+                    resultObject.put(column.getName(),
+                                     new DoubleNode(singlePageRecordReader.getDouble(column)));
+                }
+
+                @Override
+                public void stringColumn(Column column)
+                {
+                    resultObject.put(column.getName(),
+                                     new TextNode(singlePageRecordReader.getString(column)));
+                }
+
+                @Override
+                public void timestampColumn(Column column)
+                {
+                    if (timestampFormat == null) {
+                        resultObject.put(column.getName(),
+                                         new LongNode(singlePageRecordReader.getTimestamp(column).getEpochSecond()));
+                    }
+                    else {
+                        // TODO(dmikurube): Implement timestamp formatting.
+                    }
+                }
+
+                @Override
+                public void jsonColumn(Column column)
+                {
+                    // TODO(dmikurube): Implement conversion from msgpack |Value| to Jackson |JsonNode|.
+                }
+            });
+        return resultObject;
+    }
+
+    private final String timestampFormat;
+}


### PR DESCRIPTION
@sakama Though it's still WIP, it will be the class to export all Embulk columns into one JSON object node without specifying column names. Can you have a quick look?