### PR TITLE
Change the place where finish() is called in RestClientInputPluginBaseUnsafe.

### DIFF
--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginBaseUnsafe.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginBaseUnsafe.java
@@ -106,6 +106,7 @@ public class RestClientInputPluginBaseUnsafe<T extends RestClientInputTaskBase>
             this.serviceResponseMapperBuilder.buildServiceResponseMapper(task);
 
         try (PageBuilder pageBuilder = new PageBuilder(Exec.getBufferAllocator(), schema, output)) {
+	    // When failing around |PageBuidler| in |ingestServiceData|, |pageBuilder.finish()| should not be called.
             TaskReport taskReport = Preconditions.checkNotNull(
                 this.serviceDataIngester.ingestServiceData(
                     task,

--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginBaseUnsafe.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginBaseUnsafe.java
@@ -106,17 +106,14 @@ public class RestClientInputPluginBaseUnsafe<T extends RestClientInputTaskBase>
             this.serviceResponseMapperBuilder.buildServiceResponseMapper(task);
 
         try (PageBuilder pageBuilder = new PageBuilder(Exec.getBufferAllocator(), schema, output)) {
-            try {
-                return Preconditions.checkNotNull(
-                    this.serviceDataIngester.ingestServiceData(
-                        task,
-                        serviceResponseMapper.createRecordImporter(),
-                        taskIndex,
-                        pageBuilder));
-            }
-            finally {
-                pageBuilder.finish();
-            }
+            TaskReport taskReport = Preconditions.checkNotNull(
+                this.serviceDataIngester.ingestServiceData(
+                    task,
+                    serviceResponseMapper.createRecordImporter(),
+                    taskIndex,
+                    pageBuilder));
+            pageBuilder.finish();
+            return taskReport;
         }
     }
 


### PR DESCRIPTION
PageBuilder#finish() is called when ingestServiceData failed. The finish() needs to be called when PageBuilder finishes writing Page objects.

As background, when PreviewExecutor executes my plugin that uses this library, it throws NullPointerException reported on https://github.com/embulk/embulk/issues/570. The cause of the issue is that PageBuilder#finish method is called twice within preview. I'm trying to fix Embulk itself to avoid this situation https://github.com/embulk/embulk/pull/571. This PR fixes the cause that the finish() is called twice within PreviewExecutor.
