### PR TITLE
Provide |Schema| and |taskIndex| in building |RecordBuffer|.

### DIFF
--- a/embulk-output-example/src/main/java/org/embulk/output/example/ExampleOutputPluginDelegate.java
+++ b/embulk-output-example/src/main/java/org/embulk/output/example/ExampleOutputPluginDelegate.java
@@ -79,7 +79,7 @@ public class ExampleOutputPluginDelegate
     }
 
     @Override  // Overridden from |RecordBufferBuildable|
-    public RecordBuffer buildRecordBuffer(PluginTask task)
+    public RecordBuffer buildRecordBuffer(PluginTask task, Schema schema, int taskIndex)
     {
         return new JacksonTaskReportRecordBuffer("records");
     }

--- a/src/main/java/org/embulk/base/restclient/RecordBufferBuildable.java
+++ b/src/main/java/org/embulk/base/restclient/RecordBufferBuildable.java
@@ -1,8 +1,9 @@
 package org.embulk.base.restclient;
 
 import org.embulk.base.restclient.record.RecordBuffer;
+import org.embulk.spi.Schema;
 
 public interface RecordBufferBuildable<T extends RestClientOutputTaskBase>
 {
-    public RecordBuffer buildRecordBuffer(T task);
+    public RecordBuffer buildRecordBuffer(T task, Schema schema, int taskIndex);
 }

--- a/src/main/java/org/embulk/base/restclient/RestClientOutputPluginBaseUnsafe.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientOutputPluginBaseUnsafe.java
@@ -65,7 +65,7 @@ public class RestClientOutputPluginBaseUnsafe<T extends RestClientOutputTaskBase
         return new RestClientPageOutput<T>(this.taskClass,
                                            task,
                                            serviceRequestMapper.createRecordExporter(),
-                                           this.recordBufferBuilder.buildRecordBuffer(task),
+                                           this.recordBufferBuilder.buildRecordBuffer(task, schema, taskIndex),
                                            schema,
                                            taskIndex);
     }


### PR DESCRIPTION
@muga Can you PTAL? Found that `RecordBuffer` sometimes needs more information.