### PR TITLE
Add dispatching delegates to implement plugins switching per Config (such as "target").

### DIFF
--- a/src/main/java/org/embulk/base/restclient/DispatchingRestClientInputPluginDelegate.java
+++ b/src/main/java/org/embulk/base/restclient/DispatchingRestClientInputPluginDelegate.java
@@ -1,0 +1,74 @@
+package org.embulk.base.restclient;
+
+import java.util.List;
+import org.embulk.base.restclient.jackson.JacksonServiceResponseMapper;
+import org.embulk.base.restclient.record.RecordImporter;
+import org.embulk.base.restclient.record.ValueLocator;
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.TaskReport;
+import org.embulk.spi.Schema;
+import org.embulk.spi.PageBuilder;
+
+public abstract class DispatchingRestClientInputPluginDelegate<T extends RestClientInputTaskBase>
+        implements RestClientInputPluginDelegate<T>
+{
+    public DispatchingRestClientInputPluginDelegate()
+    {
+        this.delegateSelected = null;
+    }
+
+    @Override  // Overridden from |InputTaskValidatable|
+    public final void validateInputTask(T task)
+    {
+        final RestClientInputPluginDelegate<T> delegate = this.cacheDelegate(task);
+        delegate.validateInputTask(task);
+    }
+
+    @Override  // Overridden from |ServiceResponseMapperBuildable|
+    public final ServiceResponseMapper<? extends ValueLocator> buildServiceResponseMapper(T task)
+    {
+        final RestClientInputPluginDelegate<T> delegate = this.cacheDelegate(task);
+        return delegate.buildServiceResponseMapper(task);
+    }
+
+    @Override  // Overridden from |ConfigDiffBuildable|
+    public final ConfigDiff buildConfigDiff(T task, Schema schema, int taskCount, List<TaskReport> taskReports)
+    {
+        final RestClientInputPluginDelegate<T> delegate = this.cacheDelegate(task);
+        return delegate.buildConfigDiff(task, schema, taskCount, taskReports);
+    }
+
+    @Override  // Overridden from |ServiceDataSplitterBuildable|
+    public final ServiceDataSplitter buildServiceDataSplitter(final T task)
+    {
+        final RestClientInputPluginDelegate<T> delegate = this.cacheDelegate(task);
+        return delegate.buildServiceDataSplitter(task);
+    }
+
+    @Override  // Overridden from |ServiceDataIngestable|
+    public final TaskReport ingestServiceData(final T task,
+                                              RecordImporter recordImporter,
+                                              int taskIndex,
+                                              PageBuilder pageBuilder)
+    {
+        final RestClientInputPluginDelegate<T> delegate = this.cacheDelegate(task);
+        return delegate.ingestServiceData(task, recordImporter, taskIndex, pageBuilder);
+    }
+
+    /**
+     * Returns an appropriate Delegate instance for the given Task.
+     *
+     * This method is to be overridden by the plugin Delegate class.
+     */
+    protected abstract RestClientInputPluginDelegate<T> dispatchPerTask(T task);
+
+    private RestClientInputPluginDelegate<T> cacheDelegate(T task)
+    {
+        if (this.delegateSelected == null) {
+            this.delegateSelected = dispatchPerTask(task);
+        }
+        return this.delegateSelected;
+    }
+
+    private RestClientInputPluginDelegate<T> delegateSelected;
+}

--- a/src/main/java/org/embulk/base/restclient/DispatchingRestClientOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/base/restclient/DispatchingRestClientOutputPluginDelegate.java
@@ -1,0 +1,62 @@
+package org.embulk.base.restclient;
+
+import java.util.List;
+import org.embulk.base.restclient.record.RecordBuffer;
+import org.embulk.base.restclient.record.ValueLocator;
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.TaskReport;
+import org.embulk.spi.Schema;
+
+public abstract class DispatchingRestClientOutputPluginDelegate<T extends RestClientOutputTaskBase>
+        implements RestClientOutputPluginDelegate<T>
+{
+    public DispatchingRestClientOutputPluginDelegate()
+    {
+        this.delegateSelected = null;
+    }
+
+    @Override  // Overridden from |OutputTaskValidatable|
+    public void validateOutputTask(T task, Schema embulkSchema, int taskCount)
+    {
+        final RestClientOutputPluginDelegate<T> delegate = this.cacheDelegate(task);
+        delegate.validateOutputTask(task, embulkSchema, taskCount);
+    }
+
+    @Override  // Overridden from |ServiceRequestMapperBuildable|
+    public ServiceRequestMapper<? extends ValueLocator> buildServiceRequestMapper(T task)
+    {
+        final RestClientOutputPluginDelegate<T> delegate = this.cacheDelegate(task);
+        return delegate.buildServiceRequestMapper(task);
+    }
+
+    @Override  // Overridden from |RecordBufferBuildable|
+    public RecordBuffer buildRecordBuffer(T task, Schema schema, int taskIndex)
+    {
+        final RestClientOutputPluginDelegate<T> delegate = this.cacheDelegate(task);
+        return delegate.buildRecordBuffer(task, schema, taskIndex);
+    }
+
+    @Override  // Overridden from |EmbulkDataEgestable|
+    public final ConfigDiff egestEmbulkData(T task, Schema schema, int taskCount, List<TaskReport> taskReports)
+    {
+        final RestClientOutputPluginDelegate<T> delegate = this.cacheDelegate(task);
+        return delegate.egestEmbulkData(task, schema, taskCount, taskReports);
+    }
+
+    /**
+     * Returns an appropriate Delegate instance for the given Task.
+     *
+     * This method is to be overridden by the plugin Delegate class.
+     */
+    protected abstract RestClientOutputPluginDelegate<T> dispatchPerTask(T task);
+
+    private RestClientOutputPluginDelegate<T> cacheDelegate(T task)
+    {
+        if (this.delegateSelected == null) {
+            this.delegateSelected = dispatchPerTask(task);
+        }
+        return this.delegateSelected;
+    }
+
+    private RestClientOutputPluginDelegate<T> delegateSelected;
+}


### PR DESCRIPTION
@muga Can you have a look?

It's to implement plugins switching its behavior per Config. Imagine an input plugin from a kind of weather service, for example:

```
in:
  type: weather_service
  target: temperature  # Ingests from https://weather.example.com/api/temperature
```
```
in:
  type: weather_service
  target: precipitation  # Ingests from https://weather.example.com/api/precipitation
```

This extended `Dispatching-Delegate` classes make implementing such plugins easier and simpler.