### PR TITLE
Update |ServiceDataSplitter| to take |Task| instead of |TaskSource| for ease.

### DIFF
--- a/embulk-input-example/src/main/java/org/embulk/input/example/ExampleInputPluginDelegate.java
+++ b/embulk-input-example/src/main/java/org/embulk/input/example/ExampleInputPluginDelegate.java
@@ -79,9 +79,9 @@ public class ExampleInputPluginDelegate
     }
 
     @Override  // Overridden from |ServiceDataSplitterBuildable|
-    public ServiceDataSplitter buildServiceDataSplitter(final PluginTask task)
+    public ServiceDataSplitter<PluginTask> buildServiceDataSplitter(final PluginTask task)
     {
-        return new DefaultServiceDataSplitter();
+        return new DefaultServiceDataSplitter<PluginTask>();
     }
 
     @Override  // Overridden from |ServiceDataIngestable|

--- a/embulk-input-example_jetty93/src/main/java/org/embulk/input/example_jetty93/ExampleJetty93InputPluginDelegate.java
+++ b/embulk-input-example_jetty93/src/main/java/org/embulk/input/example_jetty93/ExampleJetty93InputPluginDelegate.java
@@ -82,9 +82,9 @@ public class ExampleJetty93InputPluginDelegate
     }
 
     @Override  // Overridden from |ServiceDataSplitterBuildable|
-    public ServiceDataSplitter buildServiceDataSplitter(final PluginTask task)
+    public ServiceDataSplitter<PluginTask> buildServiceDataSplitter(final PluginTask task)
     {
-        return new DefaultServiceDataSplitter();
+        return new DefaultServiceDataSplitter<PluginTask>();
     }
 
     @Override  // Overridden from |ServiceDataIngestable|

--- a/src/main/java/org/embulk/base/restclient/DefaultServiceDataSplitter.java
+++ b/src/main/java/org/embulk/base/restclient/DefaultServiceDataSplitter.java
@@ -3,17 +3,17 @@ package org.embulk.base.restclient;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.Schema;
 
-public class DefaultServiceDataSplitter
-        extends ServiceDataSplitter
+public class DefaultServiceDataSplitter<T extends RestClientInputTaskBase>
+        extends ServiceDataSplitter<T>
 {
     @Override
-    public int splitToTasks(TaskSource taskSourceToHint)
+    public int numberToSplitWithHintingInTask(T taskToHint)
     {
         return 1;
     }
 
     @Override
-    public void hintPerTask(TaskSource taskSourceToHint, Schema schema, int taskIndex)
+    public void hintInEachSplitTask(T taskToHint, Schema schema, int taskIndex)
     {
     }
 }

--- a/src/main/java/org/embulk/base/restclient/DispatchingRestClientInputPluginDelegate.java
+++ b/src/main/java/org/embulk/base/restclient/DispatchingRestClientInputPluginDelegate.java
@@ -39,7 +39,7 @@ public abstract class DispatchingRestClientInputPluginDelegate<T extends RestCli
     }
 
     @Override  // Overridden from |ServiceDataSplitterBuildable|
-    public final ServiceDataSplitter buildServiceDataSplitter(final T task)
+    public final ServiceDataSplitter<T> buildServiceDataSplitter(final T task)
     {
         final RestClientInputPluginDelegate<T> delegate = this.cacheDelegate(task);
         return delegate.buildServiceDataSplitter(task);

--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginBaseUnsafe.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginBaseUnsafe.java
@@ -61,9 +61,9 @@ public class RestClientInputPluginBaseUnsafe<T extends RestClientInputTaskBase>
              serviceDataIngester,
              new ServiceDataSplitterBuildable<T>() {
                  @Override
-                 public ServiceDataSplitter buildServiceDataSplitter(T task)
+                 public ServiceDataSplitter<T> buildServiceDataSplitter(T task)
                  {
-                     return new DefaultServiceDataSplitter();
+                     return new DefaultServiceDataSplitter<T>();
                  }
              },
              serviceResponseMapperBuilder);
@@ -81,10 +81,9 @@ public class RestClientInputPluginBaseUnsafe<T extends RestClientInputTaskBase>
         final T task = loadConfig(config, this.taskClass);
         this.inputTaskValidator.validateInputTask(task);
 
-        TaskSource dumpedTaskSource = task.dump();
         final int taskCount = this.serviceDataSplitterBuilder
             .buildServiceDataSplitter(task)
-            .splitToTasks(dumpedTaskSource);
+            .numberToSplitWithHintingInTask(task);
 
         final Schema schema = this.serviceResponseMapperBuilder.buildServiceResponseMapper(task).getEmbulkSchema();
         return resume(task.dump(), schema, taskCount, control);
@@ -109,7 +108,7 @@ public class RestClientInputPluginBaseUnsafe<T extends RestClientInputTaskBase>
         final T task = taskSource.loadTask(this.taskClass);
         this.serviceDataSplitterBuilder
             .buildServiceDataSplitter(task)
-            .hintPerTask(taskSource, schema, taskIndex);
+            .hintInEachSplitTask(task, schema, taskIndex);
 
         final ServiceResponseMapper<? extends ValueLocator> serviceResponseMapper =
             this.serviceResponseMapperBuilder.buildServiceResponseMapper(task);

--- a/src/main/java/org/embulk/base/restclient/ServiceDataSplitter.java
+++ b/src/main/java/org/embulk/base/restclient/ServiceDataSplitter.java
@@ -3,8 +3,32 @@ package org.embulk.base.restclient;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.Schema;
 
-public abstract class ServiceDataSplitter
+/**
+ * ServiceDataSplitter controls how the data are split into multiple Embulk tasks.
+ *
+ * ServiceDataSplitter just calculates how many tasks to split, and provides hints to
+ * {@code ServideDataIngestable#ingestServiceData} through the plugin's {@code Task}.
+ */
+public abstract class ServiceDataSplitter<T extends RestClientInputTaskBase>
 {
-    public abstract int splitToTasks(TaskSource taskSourceToHint);
-    public abstract void hintPerTask(TaskSource taskSourceToHint, Schema schema, int taskIndex);
+    /**
+     * Calculates and returns how many tasks to split for the given Config.
+     *
+     * It may add some hint entries in the given Task.
+     *
+     * It runs in {@code InputPlugin#transaction} just once before splitting into parallel tasks.
+     *
+     * NOTE: This |numberToSplitWithHintingInTask| cannot share fields with |hintInEachSplitTask|.
+     */
+    public abstract int numberToSplitWithHintingInTask(T taskToHint);
+
+    /**
+     * Adds hint entries in the given split Task.
+     *
+     * It runs in {@code InputPlugin#run} in each task after splitting.
+     *
+     * NOTE: This |numberToSplitWithHintingInTask| cannot share fields with |hintInEachSplitTask|.
+     * |numberToSplitWithHintingInTask| runs in |transaction|, and |hintInEachSplitTask| runs in |run|.
+     */
+    public abstract void hintInEachSplitTask(T taskToHint, Schema schema, int taskIndex);
 }

--- a/src/main/java/org/embulk/base/restclient/ServiceDataSplitterBuildable.java
+++ b/src/main/java/org/embulk/base/restclient/ServiceDataSplitterBuildable.java
@@ -2,5 +2,5 @@ package org.embulk.base.restclient;
 
 public interface ServiceDataSplitterBuildable<T extends RestClientInputTaskBase>
 {
-    public ServiceDataSplitter buildServiceDataSplitter(T task);
+    public ServiceDataSplitter<T> buildServiceDataSplitter(T task);
 }

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
@@ -197,9 +197,9 @@ public class ShopifyInputPluginDelegate
     }
 
     @Override  // Overridden from |ServiceDataSplitterBuildable|
-    public ServiceDataSplitter buildServiceDataSplitter(final PluginTask task)
+    public ServiceDataSplitter<PluginTask> buildServiceDataSplitter(final PluginTask task)
     {
-        return new DefaultServiceDataSplitter();
+        return new DefaultServiceDataSplitter<PluginTask>();
     }
 
     private ArrayNode extractArrayField(String content)


### PR DESCRIPTION
It renames methods in |ServiceDataSplitter| for readability as well.

@muga Can you have a look?