### PR TITLE
Add Null check at JacksonAllInObjectScope to avoid NullPointerException

### DIFF
--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
@@ -59,20 +59,23 @@ public class JacksonAllInObjectScope
                 @Override
                 public void stringColumn(Column column)
                 {
-                    resultObject.put(column.getName(),
-                                     singlePageRecordReader.getString(column));
+                    if (!singlePageRecordReader.isNull(column)) {
+                        resultObject.put(column.getName(),
+                                         singlePageRecordReader.getString(column));
+                    }
                 }
 
                 @Override
                 public void timestampColumn(Column column)
                 {
-                    if (timestampFormatter == null) {
-                        resultObject.put(column.getName(),
-                                         singlePageRecordReader.getTimestamp(column).getEpochSecond());
-                    }
-                    else {
-                        resultObject.put(column.getName(),
-                                         timestampFormatter.format(singlePageRecordReader.getTimestamp(column)));
+                    if (!singlePageRecordReader.isNull(column)) {
+                        if (timestampFormatter == null) {
+                            resultObject.put(column.getName(),
+                                             singlePageRecordReader.getTimestamp(column).getEpochSecond());
+                        } else {
+                            resultObject.put(column.getName(),
+                                             timestampFormatter.format(singlePageRecordReader.getTimestamp(column)));
+                        }
                     }
                 }
 
@@ -81,8 +84,10 @@ public class JacksonAllInObjectScope
                 {
                     // TODO(dmikurube): Use jackson-datatype-msgpack.
                     // See: https://github.com/embulk/embulk-base-restclient/issues/32
-                    resultObject.set(column.getName(),
-                                     jsonParser.parseJsonObject(singlePageRecordReader.getJson(column).toJson()));
+                    if (!singlePageRecordReader.isNull(column)) {
+                        resultObject.set(column.getName(),
+                                jsonParser.parseJsonObject(singlePageRecordReader.getJson(column).toJson()));
+                    }
                 }
             });
         return resultObject;


### PR DESCRIPTION
### ~~TODO~~

* ~~This PR depends on https://github.com/embulk/embulk/pull/654~~
    * ~~Need to update Embulk version at build.gradle~~

### Changes
I was trying to fix `ArrayIndexOutOfBoundsException` that happens with [embulk-output-elasticsearch](https://github.com/muga/embulk-output-elasticsearch) at #86 and revised it.
I tried https://github.com/embulk/embulk/pull/654 and got `NullPointerException` instead of `ArrayIndexOutOfBoundsException`.
This should valid behavior. Then, I added Null check to `JacksonAllInObjectScope#{string|timestamp|json}Column` to avoid this failure.

### Stacktrace
```
Caused by: java.lang.NullPointerException
	at org.embulk.spi.time.TimestampFormatter.format(TimestampFormatter.java:93)
	at org.embulk.base.restclient.jackson.scope.JacksonAllInObjectScope$1.timestampColumn(JacksonAllInObjectScope.java:74)
	at org.embulk.spi.Column.visit(Column.java:60)
	at org.embulk.spi.Schema.visitColumns(Schema.java:81)
	at org.embulk.base.restclient.jackson.scope.JacksonAllInObjectScope.scopeObject(JacksonAllInObjectScope.java:36)
	at org.embulk.base.restclient.jackson.scope.JacksonObjectScopeBase.scopeEmbulkValues(JacksonObjectScopeBase.java:17)
	at org.embulk.base.restclient.jackson.scope.JacksonObjectScopeBase.scopeEmbulkValues(JacksonObjectScopeBase.java:9)
	at org.embulk.base.restclient.record.ValueExporter.exportValueToBuildRecord(ValueExporter.java:14)
	at org.embulk.base.restclient.record.RecordExporter.exportRecord(RecordExporter.java:18)
	at org.embulk.base.restclient.RestClientPageOutput.add(RestClientPageOutput.java:43)
	at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput$OutputWorker.call(LocalExecutorPlugin.java:394)
	at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput$OutputWorker.call(LocalExecutorPlugin.java:319)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
	Suppressed: java.lang.NullPointerException
		... 16 more
	Suppressed: java.lang.NullPointerException
		... 16 more
	Suppressed: java.lang.NullPointerException
		... 16 more
```