### PR TITLE
Add close method in RecordBuffer

### DIFF
--- a/src/main/java/org/embulk/base/restclient/RestClientPageOutput.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientPageOutput.java
@@ -54,7 +54,7 @@ public class RestClientPageOutput<T extends RestClientOutputTaskBase>
     @Override
     public void close()
     {
-	this.recordBuffer.close();
+        this.recordBuffer.close();
     }
 
     @Override

--- a/src/main/java/org/embulk/base/restclient/RestClientPageOutput.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientPageOutput.java
@@ -54,7 +54,7 @@ public class RestClientPageOutput<T extends RestClientOutputTaskBase>
     @Override
     public void close()
     {
-        // TODO(dmikurube): Implement.
+	this.recordBuffer.close();
     }
 
     @Override

--- a/src/main/java/org/embulk/base/restclient/RestClientPageOutput.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientPageOutput.java
@@ -48,7 +48,7 @@ public class RestClientPageOutput<T extends RestClientOutputTaskBase>
     @Override
     public void finish()
     {
-        // TODO(dmikurube): Implement.
+        this.recordBuffer.finish();
     }
 
     @Override

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonTaskReportRecordBuffer.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonTaskReportRecordBuffer.java
@@ -40,6 +40,16 @@ public class JacksonTaskReportRecordBuffer
     }
 
     @Override
+    public void finish()
+    {
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    @Override
     public TaskReport commitWithTaskReportUpdated(TaskReport taskReport)
     {
         taskReport.set(this.attributeName, this.records);

--- a/src/main/java/org/embulk/base/restclient/record/RecordBuffer.java
+++ b/src/main/java/org/embulk/base/restclient/record/RecordBuffer.java
@@ -17,7 +17,12 @@ import org.embulk.config.TaskReport;
  * - Put the output to an external storage (e.g. S3), and include a pointer to the storage in {@code TaskReport}.
  *
  * Or, it is possible to commit directly from {@code RecordBuffer}. But, the destination must accept parallel
- * uploads, and developers may need to take care of transactions and orders.
+ * uploads, and developers may need to take care of transactions and orders. If {@code RecordBuffer} might own
+ * external resource for uploads, it might need to release the resource. The resource can be released in the
+ * finish or close method. In almost all cases, the external resource might have same
+ * lifecycle as {@code RecordBuffer}'s. The close method might be used for releasing the resource. The method is
+ * called when {@code PageOutput} (and {@code RecordBuffer}) is closed. If the resource needs to be released when
+ * {@code PageOutput} finishes, the finish method needs to be used.
  */
 public abstract class RecordBuffer
 {

--- a/src/main/java/org/embulk/base/restclient/record/RecordBuffer.java
+++ b/src/main/java/org/embulk/base/restclient/record/RecordBuffer.java
@@ -22,6 +22,7 @@ import org.embulk.config.TaskReport;
 public abstract class RecordBuffer
 {
     public abstract void bufferRecord(ServiceRecord record);
+    public abstract void finish();
     public abstract void close();
     public abstract TaskReport commitWithTaskReportUpdated(TaskReport taskReport);
 }

--- a/src/main/java/org/embulk/base/restclient/record/RecordBuffer.java
+++ b/src/main/java/org/embulk/base/restclient/record/RecordBuffer.java
@@ -22,5 +22,6 @@ import org.embulk.config.TaskReport;
 public abstract class RecordBuffer
 {
     public abstract void bufferRecord(ServiceRecord record);
+    public abstract void close();
     public abstract TaskReport commitWithTaskReportUpdated(TaskReport taskReport);
 }

--- a/src/main/java/org/embulk/base/restclient/record/RecordBuffer.java
+++ b/src/main/java/org/embulk/base/restclient/record/RecordBuffer.java
@@ -17,17 +17,30 @@ import org.embulk.config.TaskReport;
  * - Put the output to an external storage (e.g. S3), and include a pointer to the storage in {@code TaskReport}.
  *
  * Or, it is possible to commit directly from {@code RecordBuffer}. But, the destination must accept parallel
- * uploads, and developers may need to take care of transactions and orders. If {@code RecordBuffer} might own
- * external resource for uploads, it might need to release the resource. The resource can be released in the
- * finish or close method. In almost all cases, the external resource might have same
- * lifecycle as {@code RecordBuffer}'s. The close method might be used for releasing the resource. The method is
- * called when {@code PageOutput} (and {@code RecordBuffer}) is closed. If the resource needs to be released when
- * {@code PageOutput} finishes, the finish method needs to be used.
+ * uploads, and developers may need to take care of transactions and orders.
+ *
+ * If {@code RecordBuffer} owns external resources for direct uploading, the resources need to be released in
+ * its {@code close} or {@code finish}. Releasing resources in {@code close} is the typical manner.
  */
 public abstract class RecordBuffer
 {
     public abstract void bufferRecord(ServiceRecord record);
+
+    /**
+     * Finishes the {@code RecordBuffer}.
+     *
+     * This method is called when {@code RestClientPageOutput#finish} is called. Implement this method usually to
+     * finish resources managed in {@code RecordBuffer}.
+     */
     public abstract void finish();
+
+    /**
+     * Closes the {@code RecordBuffer}.
+     *
+     * This method is called when {@code RestClientPageOutput#close} is called. Implement this method usually to
+     * close resources managed in {@code RecordBuffer}.
+     */
     public abstract void close();
+
     public abstract TaskReport commitWithTaskReportUpdated(TaskReport taskReport);
 }


### PR DESCRIPTION
This PR adds `close` method in `RecordBuffer`. The method is called in `RestClientPageOutput#close()`. A output plugin's `RecordBuffer` object sometimes has (owns) an external resource. In this case, the resource needs to be closed when `RestClientPageOutput#close()` is called.