### PR TITLE
Use Oracle JDK8 to build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
-jdk: oraclejdk7
+jdk: oraclejdk8
 script: ./gradlew clean test

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ task enforceJavaVersion {
     doLast {
         def foundVersion = JavaVersion.current();
         if (foundVersion != javaVersion) {
-            if (project.hasProperty('ignoreJavaVersion')) {
+            if (project.hasProperty('ignoreJavaVersion') || System.getenv('TRAVIS') == 'true') {
                 println "[WARN] Java " + javaVersion + " is required, but found Java " + foundVersion + "."
             } else {
                 throw new IllegalStateException("[ERROR] Java " + javaVersion + " is required, but found Java " + foundVersion + ". (Specify -PignoreJavaVersion to ignore the check.)");


### PR DESCRIPTION
@muga Can you have a look?

While this library still needs to be built with Java 7, it does not work on Travis
due to SSL versions and Gradle problems. Using Oracle JDK8 on Travis to workaround.