### PR TITLE
Fix: Null values are not being handled properly for numeric types and booleans

### DIFF
--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
@@ -38,22 +38,34 @@ public class JacksonAllInObjectScope
                 @Override
                 public void booleanColumn(Column column)
                 {
-                    resultObject.put(column.getName(),
-                                     singlePageRecordReader.getBoolean(column));
+                    if (!singlePageRecordReader.isNull(column)) {
+                        resultObject.put(column.getName(),
+                                singlePageRecordReader.getBoolean(column));
+                    } else {
+                        resultObject.putNull(column.getName());
+                    }
                 }
 
                 @Override
                 public void longColumn(Column column)
                 {
-                    resultObject.put(column.getName(),
-                                     singlePageRecordReader.getLong(column));
+                    if (!singlePageRecordReader.isNull(column)) {
+                        resultObject.put(column.getName(),
+                                singlePageRecordReader.getLong(column));
+                    } else {
+                        resultObject.putNull(column.getName());
+                    }
                 }
 
                 @Override
                 public void doubleColumn(Column column)
                 {
-                    resultObject.put(column.getName(),
-                                     singlePageRecordReader.getDouble(column));
+                    if (!singlePageRecordReader.isNull(column)) {
+                        resultObject.put(column.getName(),
+                                singlePageRecordReader.getDouble(column));
+                    } else {
+                        resultObject.putNull(column.getName());
+                    }
                 }
 
                 @Override
@@ -62,6 +74,8 @@ public class JacksonAllInObjectScope
                     if (!singlePageRecordReader.isNull(column)) {
                         resultObject.put(column.getName(),
                                          singlePageRecordReader.getString(column));
+                    } else {
+                        resultObject.putNull(column.getName());
                     }
                 }
 
@@ -76,6 +90,8 @@ public class JacksonAllInObjectScope
                             resultObject.put(column.getName(),
                                              timestampFormatter.format(singlePageRecordReader.getTimestamp(column)));
                         }
+                    } else {
+                        resultObject.putNull(column.getName());
                     }
                 }
 
@@ -87,6 +103,8 @@ public class JacksonAllInObjectScope
                     if (!singlePageRecordReader.isNull(column)) {
                         resultObject.set(column.getName(),
                                 jsonParser.parseJsonObject(singlePageRecordReader.getJson(column).toJson()));
+                    } else {
+                        resultObject.putNull(column.getName());
                     }
                 }
             });

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
@@ -19,13 +19,24 @@ public class JacksonAllInObjectScope
 {
     public JacksonAllInObjectScope()
     {
-        this(null);
+        this(null, false);
+    }
+
+    public JacksonAllInObjectScope(boolean fillsJsonNullForEmbulkNull)
+    {
+        this(null, fillsJsonNullForEmbulkNull);
     }
 
     public JacksonAllInObjectScope(final TimestampFormatter timestampFormatter)
     {
+        this(timestampFormatter, false);
+    }
+
+    public JacksonAllInObjectScope(final TimestampFormatter timestampFormatter, boolean fillsJsonNullForEmbulkNull)
+    {
         this.timestampFormatter = timestampFormatter;
         this.jsonParser = new StringJsonParser();
+        this.fillsJsonNullForEmbulkNull = fillsJsonNullForEmbulkNull;
     }
 
     @Override
@@ -41,7 +52,7 @@ public class JacksonAllInObjectScope
                     if (!singlePageRecordReader.isNull(column)) {
                         resultObject.put(column.getName(),
                                 singlePageRecordReader.getBoolean(column));
-                    } else {
+                    } else if (fillsJsonNullForEmbulkNull) {
                         resultObject.putNull(column.getName());
                     }
                 }
@@ -52,7 +63,7 @@ public class JacksonAllInObjectScope
                     if (!singlePageRecordReader.isNull(column)) {
                         resultObject.put(column.getName(),
                                 singlePageRecordReader.getLong(column));
-                    } else {
+                    } else if (fillsJsonNullForEmbulkNull)  {
                         resultObject.putNull(column.getName());
                     }
                 }
@@ -63,7 +74,7 @@ public class JacksonAllInObjectScope
                     if (!singlePageRecordReader.isNull(column)) {
                         resultObject.put(column.getName(),
                                 singlePageRecordReader.getDouble(column));
-                    } else {
+                    } else if (fillsJsonNullForEmbulkNull) {
                         resultObject.putNull(column.getName());
                     }
                 }
@@ -74,7 +85,7 @@ public class JacksonAllInObjectScope
                     if (!singlePageRecordReader.isNull(column)) {
                         resultObject.put(column.getName(),
                                          singlePageRecordReader.getString(column));
-                    } else {
+                    } else if (fillsJsonNullForEmbulkNull) {
                         resultObject.putNull(column.getName());
                     }
                 }
@@ -90,7 +101,7 @@ public class JacksonAllInObjectScope
                             resultObject.put(column.getName(),
                                              timestampFormatter.format(singlePageRecordReader.getTimestamp(column)));
                         }
-                    } else {
+                    } else if (fillsJsonNullForEmbulkNull) {
                         resultObject.putNull(column.getName());
                     }
                 }
@@ -113,4 +124,5 @@ public class JacksonAllInObjectScope
 
     private final TimestampFormatter timestampFormatter;
     private final StringJsonParser jsonParser;
+    private boolean fillsJsonNullForEmbulkNull;
 }

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
@@ -124,5 +124,5 @@ public class JacksonAllInObjectScope
 
     private final TimestampFormatter timestampFormatter;
     private final StringJsonParser jsonParser;
-    private boolean fillsJsonNullForEmbulkNull;
+    private final boolean fillsJsonNullForEmbulkNull;
 }

--- a/src/test/java/org/embulk/base/restclient/NoNullsOutputTestPlugin.java
+++ b/src/test/java/org/embulk/base/restclient/NoNullsOutputTestPlugin.java
@@ -1,0 +1,10 @@
+package org.embulk.base.restclient;
+
+class NoNullsOutputTestPlugin
+        extends RestClientOutputPluginBase<OutputTestPluginDelegate.PluginTask>
+{
+    NoNullsOutputTestPlugin()
+    {
+        super(OutputTestPluginDelegate.PluginTask.class, new OutputTestPluginDelegate(false));
+    }
+}

--- a/src/test/java/org/embulk/base/restclient/NoNullsRestClientPageOutputTest.java
+++ b/src/test/java/org/embulk/base/restclient/NoNullsRestClientPageOutputTest.java
@@ -1,0 +1,113 @@
+package org.embulk.base.restclient;
+
+import com.google.common.collect.Lists;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.base.restclient.OutputTestPluginDelegate.PluginTask;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.*;
+import org.embulk.spi.time.Timestamp;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class NoNullsRestClientPageOutputTest {
+
+    @BeforeClass
+    public static void initializeConstant()
+    {
+    }
+
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+    private OutputTestUtils utils;
+    private NoNullsOutputTestPlugin plugin;
+
+    @Before
+    public void createResources() throws Exception
+    {
+        utils = new OutputTestUtils();
+        utils.initializeConstant();
+//        PluginTask task = utils.configJSON().loadConfig(PluginTask.class);
+
+        plugin = new NoNullsOutputTestPlugin();
+    }
+
+    @Test
+    public void testSomething()
+    {
+
+    }
+
+    @Test
+    public void testOutputWithNullValues() throws Exception
+    {
+        ConfigSource config = utils.configJSON();
+        Schema schema = utils.JSONSchema();
+        PluginTask task = config.loadConfig(PluginTask.class);
+        plugin.transaction(config, schema, 0, new OutputPlugin.Control() {
+            @Override
+            public List<TaskReport> run(TaskSource taskSource)
+            {
+                return Lists.newArrayList(Exec.newTaskReport());
+            }
+        });
+        TransactionalPageOutput output = plugin.open(task.dump(), schema, 0);
+
+        // id, long, timestamp, boolean, double, string
+        List<Page> pages = PageTestUtils.buildPage(runtime.getBufferAllocator(), schema, 1L, null, null, null, null, null);
+        assertThat(pages.size(), is(1));
+        for (Page page : pages) {
+            output.add(page);
+        }
+
+        output.finish();
+        output.commit();
+
+        ArrayList<OutputTestRecordBuffer> buffers = OutputTestPluginDelegate.getBuffers();
+
+        String res = buffers.get(0).toString();
+
+        assertThat(res, is("[{\"id\":1}]"));
+    }
+
+    @Test
+    public void testOutputWithRegularValues() throws Exception
+    {
+        ConfigSource config = utils.configJSON();
+        Schema schema = utils.JSONSchema();
+        PluginTask task = config.loadConfig(PluginTask.class);
+        plugin.transaction(config, schema, 0, new OutputPlugin.Control() {
+            @Override
+            public List<TaskReport> run(TaskSource taskSource)
+            {
+                return Lists.newArrayList(Exec.newTaskReport());
+            }
+        });
+        TransactionalPageOutput output = plugin.open(task.dump(), schema, 0);
+
+        // id, long, timestamp, boolean, double, string
+        List<Page> pages = PageTestUtils.buildPage(runtime.getBufferAllocator(), schema, 2L, 42L, Timestamp.ofEpochSecond(1509738161), true, 123.45, "embulk");
+        assertThat(pages.size(), is(1));
+        for (Page page : pages) {
+            output.add(page);
+        }
+
+        output.finish();
+        output.commit();
+
+        ArrayList<OutputTestRecordBuffer> buffers = OutputTestPluginDelegate.getBuffers();
+
+        String res = buffers.get(0).toString();
+
+        assertThat(res, is("[{\"id\":2,\"long\":42,\"timestamp\":\"2017-11-03T19:42:41.000+0000\",\"boolean\":true,\"double\":123.45,\"string\":\"embulk\"}]"));
+    }
+}

--- a/src/test/java/org/embulk/base/restclient/OutputTestPlugin.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestPlugin.java
@@ -5,6 +5,6 @@ class OutputTestPlugin
 {
     OutputTestPlugin()
     {
-        super(OutputTestPluginDelegate.PluginTask.class, new OutputTestPluginDelegate());
+        super(OutputTestPluginDelegate.PluginTask.class, new OutputTestPluginDelegate(true));
     }
 }

--- a/src/test/java/org/embulk/base/restclient/OutputTestPlugin.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestPlugin.java
@@ -1,0 +1,10 @@
+package org.embulk.base.restclient;
+
+class OutputTestPlugin
+        extends RestClientOutputPluginBase<OutputTestPluginDelegate.PluginTask>
+{
+    OutputTestPlugin()
+    {
+        super(OutputTestPluginDelegate.PluginTask.class, new OutputTestPluginDelegate());
+    }
+}

--- a/src/test/java/org/embulk/base/restclient/OutputTestPluginDelegate.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestPluginDelegate.java
@@ -1,0 +1,70 @@
+package org.embulk.base.restclient;
+
+import org.embulk.base.restclient.jackson.JacksonServiceRequestMapper;
+import org.embulk.base.restclient.jackson.JacksonTopLevelValueLocator;
+import org.embulk.base.restclient.jackson.scope.JacksonAllInObjectScope;
+import org.embulk.base.restclient.record.RecordBuffer;
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.TaskReport;
+import org.embulk.spi.Exec;
+import org.embulk.spi.Schema;
+import org.embulk.spi.time.TimestampFormatter;
+import org.joda.time.DateTimeZone;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OutputTestPluginDelegate
+        implements RestClientOutputPluginDelegate<OutputTestPluginDelegate.PluginTask>
+{
+
+    private static ArrayList<OutputTestRecordBuffer> buffers;
+
+    OutputTestPluginDelegate()
+    {
+        buffers = new ArrayList<>();
+    }
+
+    public interface PluginTask
+            extends RestClientOutputTaskBase, TimestampFormatter.Task
+    {
+
+    }
+
+    @Override  // Overridden from |OutputTaskValidatable|
+    public void validateOutputTask(PluginTask task, Schema embulkSchema, int taskCount)
+    {
+
+    }
+
+    @Override  // Overridden from |ServiceRequestMapperBuildable|
+    public JacksonServiceRequestMapper buildServiceRequestMapper(PluginTask task)
+    {
+        TimestampFormatter formatter = new TimestampFormatter(task.getJRuby(), "%Y-%m-%dT%H:%M:%S.%3N%z", DateTimeZone.forID("UTC"));
+
+        return JacksonServiceRequestMapper.builder()
+                .add(new JacksonAllInObjectScope(formatter), new JacksonTopLevelValueLocator("record"))
+                .build();
+    }
+
+    @Override  // Overridden from |RecordBufferBuildable|
+    public RecordBuffer buildRecordBuffer(PluginTask task, Schema schema, int taskIndex)
+    {
+        OutputTestRecordBuffer buffer = new OutputTestRecordBuffer("records", task);
+        OutputTestPluginDelegate.buffers.add(buffer);
+        return buffer;
+    }
+
+    @Override
+    public ConfigDiff egestEmbulkData(final PluginTask task,
+                                      Schema schema,
+                                      int taskIndex,
+                                      List<TaskReport> taskReports)
+    {
+        return Exec.newConfigDiff();
+    }
+
+    static ArrayList<OutputTestRecordBuffer> getBuffers() {
+        return OutputTestPluginDelegate.buffers;
+    }
+}

--- a/src/test/java/org/embulk/base/restclient/OutputTestPluginDelegate.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestPluginDelegate.java
@@ -20,9 +20,10 @@ public class OutputTestPluginDelegate
 
     private static ArrayList<OutputTestRecordBuffer> buffers;
 
-    OutputTestPluginDelegate()
+    OutputTestPluginDelegate(boolean outputNulls)
     {
         buffers = new ArrayList<>();
+        this.outputNulls = outputNulls;
     }
 
     public interface PluginTask
@@ -43,7 +44,7 @@ public class OutputTestPluginDelegate
         TimestampFormatter formatter = new TimestampFormatter(task.getJRuby(), "%Y-%m-%dT%H:%M:%S.%3N%z", DateTimeZone.forID("UTC"));
 
         return JacksonServiceRequestMapper.builder()
-                .add(new JacksonAllInObjectScope(formatter), new JacksonTopLevelValueLocator("record"))
+                .add(new JacksonAllInObjectScope(formatter, this.outputNulls), new JacksonTopLevelValueLocator("record"))
                 .build();
     }
 
@@ -67,4 +68,6 @@ public class OutputTestPluginDelegate
     static ArrayList<OutputTestRecordBuffer> getBuffers() {
         return OutputTestPluginDelegate.buffers;
     }
+
+    private boolean outputNulls;
 }

--- a/src/test/java/org/embulk/base/restclient/OutputTestRecordBuffer.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestRecordBuffer.java
@@ -1,0 +1,81 @@
+package org.embulk.base.restclient;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.google.common.base.Throwables;
+import org.embulk.base.restclient.jackson.JacksonServiceRecord;
+import org.embulk.base.restclient.record.RecordBuffer;
+import org.embulk.base.restclient.record.ServiceRecord;
+import org.embulk.config.TaskReport;
+import org.embulk.spi.Exec;
+
+import org.embulk.base.restclient.OutputTestPluginDelegate.PluginTask;
+
+import java.io.IOException;
+
+public class OutputTestRecordBuffer
+        extends RecordBuffer {
+
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final String attributeName;
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final PluginTask task;
+    private final ObjectMapper mapper;
+    private ArrayNode records;
+    private long totalCount;
+
+    OutputTestRecordBuffer(String attributeName, OutputTestPluginDelegate.PluginTask task)
+    {
+        this.attributeName = attributeName;
+        this.task = task;
+        this.mapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, false);
+        this.records = JsonNodeFactory.instance.arrayNode();
+    }
+
+    @Override
+    public void bufferRecord(ServiceRecord serviceRecord)
+    {
+        JacksonServiceRecord jacksonServiceRecord;
+        try {
+            jacksonServiceRecord = (JacksonServiceRecord) serviceRecord;
+            JsonNode record = mapper.readTree(jacksonServiceRecord.toString()).get("record");
+
+            totalCount++;
+
+            records.add(record);
+        }
+        catch (ClassCastException ex) {
+            throw new RuntimeException(ex);
+        }
+        catch (IOException ex) {
+            throw Throwables.propagate(ex);
+        }
+    }
+
+    @Override
+    public void finish()
+    {
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    @Override
+    public TaskReport commitWithTaskReportUpdated(TaskReport taskReport)
+    {
+        return Exec.newTaskReport().set("inserted", totalCount);
+    }
+
+    @Override
+    public String toString()
+    {
+        return this.records.toString();
+    }
+}

--- a/src/test/java/org/embulk/base/restclient/OutputTestUtils.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestUtils.java
@@ -1,0 +1,53 @@
+package org.embulk.base.restclient;
+
+import com.google.common.collect.ImmutableMap;
+import org.embulk.config.ConfigSource;
+import org.embulk.spi.Exec;
+import org.embulk.spi.Schema;
+import org.embulk.spi.type.Types;
+
+class OutputTestUtils {
+
+    private static String JSON_PATH_PREFIX;
+
+    void initializeConstant()
+    {
+        //noinspection ConstantConditions
+        JSON_PATH_PREFIX = OutputTestUtils.class.getClassLoader().getResource("sample_01.json").getPath();
+    }
+
+    ConfigSource configJSON()
+    {
+        return Exec.newConfigSource()
+                .set("in", inputConfigJSON())
+                .set("parser", parserConfigJSON());
+    }
+
+    private ImmutableMap<String, Object> inputConfigJSON()
+    {
+        ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
+        builder.put("type", "file");
+        builder.put("path_prefix", JSON_PATH_PREFIX);
+        builder.put("last_path", "");
+        return builder.build();
+    }
+
+    private ImmutableMap<String, Object> parserConfigJSON()
+    {
+        ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
+        return builder.build();
+    }
+
+    Schema JSONSchema()
+    {
+        return Schema.builder()
+                .add("id", Types.LONG)
+                .add("long", Types.LONG)
+                .add("timestamp", Types.TIMESTAMP)
+                .add("boolean", Types.BOOLEAN)
+                .add("double", Types.DOUBLE)
+                .add("string", Types.STRING)
+                .build();
+    }
+
+}

--- a/src/test/java/org/embulk/base/restclient/RestClientPageOutputTest.java
+++ b/src/test/java/org/embulk/base/restclient/RestClientPageOutputTest.java
@@ -1,0 +1,117 @@
+package org.embulk.base.restclient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.*;
+import org.embulk.spi.time.Timestamp;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.embulk.base.restclient.OutputTestPluginDelegate.PluginTask;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class RestClientPageOutputTest {
+
+    @BeforeClass
+    public static void initializeConstant()
+    {
+    }
+
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+    private OutputTestUtils utils;
+    private OutputTestPlugin plugin;
+
+    @Before
+    public void createResources() throws Exception
+    {
+        utils = new OutputTestUtils();
+        utils.initializeConstant();
+//        PluginTask task = utils.configJSON().loadConfig(PluginTask.class);
+
+        plugin = new OutputTestPlugin();
+    }
+
+    @Test
+    public void testSomething()
+    {
+
+    }
+
+    @Test
+    public void testOutputWithNullValues() throws Exception
+    {
+        ConfigSource config = utils.configJSON();
+        Schema schema = utils.JSONSchema();
+        PluginTask task = config.loadConfig(PluginTask.class);
+        plugin.transaction(config, schema, 0, new OutputPlugin.Control() {
+            @Override
+            public List<TaskReport> run(TaskSource taskSource)
+            {
+                return Lists.newArrayList(Exec.newTaskReport());
+            }
+        });
+        TransactionalPageOutput output = plugin.open(task.dump(), schema, 0);
+
+        // id, long, timestamp, boolean, double, string
+        List<Page> pages = PageTestUtils.buildPage(runtime.getBufferAllocator(), schema, 1L, null, null, null, null, null);
+        assertThat(pages.size(), is(1));
+        for (Page page : pages) {
+            output.add(page);
+        }
+
+        output.finish();
+        output.commit();
+
+        ArrayList<OutputTestRecordBuffer> buffers = OutputTestPluginDelegate.getBuffers();
+
+        String res = buffers.get(0).toString();
+
+        assertThat(res, is("[{\"id\":1,\"long\":null,\"timestamp\":null,\"boolean\":null,\"double\":null,\"string\":null}]"));
+    }
+
+    @Test
+    public void testOutputWithRegularValues() throws Exception
+    {
+        ConfigSource config = utils.configJSON();
+        Schema schema = utils.JSONSchema();
+        PluginTask task = config.loadConfig(PluginTask.class);
+        plugin.transaction(config, schema, 0, new OutputPlugin.Control() {
+            @Override
+            public List<TaskReport> run(TaskSource taskSource)
+            {
+                return Lists.newArrayList(Exec.newTaskReport());
+            }
+        });
+        TransactionalPageOutput output = plugin.open(task.dump(), schema, 0);
+
+        // id, long, timestamp, boolean, double, string
+        List<Page> pages = PageTestUtils.buildPage(runtime.getBufferAllocator(), schema, 2L, 42L, Timestamp.ofEpochSecond(1509738161), true, 123.45, "embulk");
+        assertThat(pages.size(), is(1));
+        for (Page page : pages) {
+            output.add(page);
+        }
+
+        output.finish();
+        output.commit();
+
+        ArrayList<OutputTestRecordBuffer> buffers = OutputTestPluginDelegate.getBuffers();
+
+        String res = buffers.get(0).toString();
+
+        assertThat(res, is("[{\"id\":2,\"long\":42,\"timestamp\":\"2017-11-03T19:42:41.000+0000\",\"boolean\":true,\"double\":123.45,\"string\":\"embulk\"}]"));
+    }
+}

--- a/src/test/resources/sample_01.json
+++ b/src/test/resources/sample_01.json
@@ -1,0 +1,2 @@
+{"id":3,"long":null,"timestamp":null,"boolean":null,"double":null,"string":null}
+{"id":4,"long":42,"timestamp":"2017-11-03T19:42:41.000+0000","boolean":true,"double":123.45,"string":"this file is not really used"}


### PR DESCRIPTION
This PR changes two things and adds some supporting tests.

## Firstly:
* **Fixed**: Boolean, Long, and Double data types did not properly handle null values, and would instead attempt to parse a value that might not exist, resulting in a default value (e.g. `0`) or worse

I believe this to be the reason that exporting data through classes based off this module, `null` numeric values are being encoded either as `0` or seemingly random numbers (leaked memory from other parts of the encoded buffer).

## Secondly:
 * **Changed**: Columns with null values are actually encoded as `null` not `undefined` (e.g. omitted)

In my opinion, when a column value is `null`, then it should be encoded in JSON as `null`. When you think about it, each column has a given name and a known data type. This means, if the column lacks a value, then the key is defined, but the value is null. As it currently stands, string, timestamp and JSON types are omitted if null, meaning their values are being encoded as `undefined`. Simply put, `null` is not the same as `undefined`. 

While this latter change I believe is technically correct, it may affect other modules based upon this one, for better or for worse.

Please let me know if there is anything else I can help with regarding this issue.

Thanks,
-Kevin