### PR TITLE
Allows readResponse() to throw exception

### DIFF
--- a/embulk-util-retryhelper-jaxrs/src/main/java/org/embulk/util/retryhelper/jaxrs/JAXRSResponseReader.java
+++ b/embulk-util-retryhelper-jaxrs/src/main/java/org/embulk/util/retryhelper/jaxrs/JAXRSResponseReader.java
@@ -13,5 +13,5 @@ package org.embulk.util.retryhelper.jaxrs;
  */
 public interface JAXRSResponseReader<T>
 {
-    T readResponse(javax.ws.rs.core.Response response);
+    T readResponse(javax.ws.rs.core.Response response) throws Exception;
 }


### PR DESCRIPTION
#### Context
Sometimes, there are exceptions during deserialization HTTP response: stream is closed, wrong expectation, etc.

#### Sample implementation
```java
    @Override
    public TsResponse readResponse(Response response)
    {
        if (!response.hasEntity()) {
            return null;
        }
        try {
            InputStream out = response.readEntity(InputStream.class);
            filter.parse(new InputSource(out));
            return (TsResponse) unmarshallerHandler.getResult();
        }
        catch (JAXBException | SAXException | IOException e) {
            throw new DataException("Unexpected response: " + e.getMessage());
        }
    }
```

#### Example exceptions

```
Caused by: org.embulk.spi.DataException: Unexpected response: Premature EOF
	at org.embulk.output.myplugin.rest.jaxrs.TsResponseEntityReader.readResponse(TsResponseEntityReader.java:86)
	at org.embulk.output.myplugin.rest.jaxrs.TsResponseEntityReader.readResponse(TsResponseEntityReader.java:26)
	at org.embulk.util.retryhelper.jaxrs.JAXRSRetryHelper$1.call(JAXRSRetryHelper.java:96)
	at org.embulk.spi.util.RetryExecutor.run(RetryExecutor.java:100)
	at org.embulk.spi.util.RetryExecutor.runInterruptible(RetryExecutor.java:77)
	at org.embulk.util.retryhelper.jaxrs.JAXRSRetryHelper.requestWithRetry(JAXRSRetryHelper.java:78)
	at org.embulk.output.myplugin.rest.jaxrs.JAXRSService.retrySend(JAXRSService.java:368)
	at org.embulk.output.myplugin.rest.jaxrs.JAXRSService.publishDataSource(JAXRSService.java:276)
	at org.embulk.output.myplugin.MyPluginOutputPluginDelegate.egestEmbulkData(MyPluginOutputPluginDelegate.java:268)
	at org.embulk.output.myplugin.MyPluginOutputPluginDelegate.egestEmbulkData(MyPluginOutputPluginDelegate.java:62)
	at org.embulk.base.restclient.RestClientOutputPluginBaseUnsafe.resume(RestClientOutputPluginBaseUnsafe.java:51)
	at org.embulk.base.restclient.RestClientOutputPluginBase.resume(RestClientOutputPluginBase.java:62)
	at org.embulk.base.restclient.RestClientOutputPluginBaseUnsafe.transaction(RestClientOutputPluginBaseUnsafe.java:43)
	at org.embulk.base.restclient.RestClientOutputPluginBase.transaction(RestClientOutputPluginBase.java:56)
	at org.embulk.exec.BulkLoader$4$1$1.transaction(BulkLoader.java:560)
	...
```

```
Caused by: org.embulk.spi.DataException: Unexpected response: The declaration for the entity "HTML.Version" must end with '>'.
	at org.embulk.output.myplugin.rest.jaxrs.TsResponseEntityReader.readResponse(TsResponseEntityReader.java:86)
	at org.embulk.output.myplugin.rest.jaxrs.JAXRSService.retrySend(JAXRSService.java:382)
	at org.embulk.output.myplugin.rest.jaxrs.JAXRSService.signIn(JAXRSService.java:168)
	at org.embulk.output.myplugin.rest.jaxrs.JAXRSService.<init>(JAXRSService.java:79)
	at org.embulk.output.myplugin.MyPluginOutputPluginDelegate.validateOutputTask(MyPluginOutputPluginDelegate.java:165)
	at org.embulk.output.myplugin.MyPluginOutputPluginDelegate.validateOutputTask(MyPluginOutputPluginDelegate.java:62)
	at org.embulk.base.restclient.RestClientOutputPluginBaseUnsafe.transaction(RestClientOutputPluginBaseUnsafe.java:42)
	at org.embulk.base.restclient.RestClientOutputPluginBase.transaction(RestClientOutputPluginBase.java:56)
	at org.embulk.exec.BulkLoader$4$1$1.transaction(BulkLoader.java:560)
	at org.embulk.exec.LocalExecutorPlugin.transaction(LocalExecutorPlugin.java:54)
	at org.embulk.exec.BulkLoader$4$1.run(BulkLoader.java:555)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(Filters.java:96)
	at org.embulk.spi.util.Filters.transaction(Filters.java:49)
	...
```

#### Target
This will allow `retryExecutor` to handle the exception, instead of `JAXRSResponseReader` to catch exception and retry itself.