### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Release 0.6.0 - 2018-08-23
+
+* [update] Allow `JAXRSResponseReader#readResponse` to throw any Exception. [#105](https://github.com/embulk/embulk-base-restclient/pull/105)
+* [incompatibility] Callers of `JAXRSResponseReader#readResponse` may need to handle Exception.
+
 Release 0.5.5 - 2017-11-15
 
 * [update] JacksonAllInObjectScipe to process null values for numeric types and booleans, with an additional option to fill null values for empty inputs. [#102](https://github.com/embulk/embulk-base-restclient/pull/102)

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ subprojects {
 
 allprojects {
     group = 'org.embulk.base.restclient'
-    version = '0.5.5'
+    version = '0.6.0'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
Releasing the version 0.6.0 of embulk-base-restclient. Can you have a look, @sakama, @tvhung83 ?

It includes #105.