### PR TITLE
Create listener per request. closes #110.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,10 @@ allprojects {
     dependencies {
         compileOnly "org.embulk:embulk-core:0.9.17"
 
-        testCompile 'junit:junit:4.12'
+        testCompile "junit:junit:4.12"
         testCompile "org.embulk:embulk-core:0.9.17"
+        testCompile "org.embulk:embulk-core:0.9.17:tests"
+        testCompile "org.embulk:embulk-test:0.9.17"
     }
 
     tasks.withType(Javadoc) {

--- a/embulk-util-retryhelper-jetty92/src/main/java/org/embulk/util/retryhelper/jetty92/InputStreamJetty92ResponseEntityReader.java
+++ b/embulk-util-retryhelper-jetty92/src/main/java/org/embulk/util/retryhelper/jetty92/InputStreamJetty92ResponseEntityReader.java
@@ -14,13 +14,19 @@ public class InputStreamJetty92ResponseEntityReader
 {
     public InputStreamJetty92ResponseEntityReader(long timeoutMillis)
     {
-        this.listener = new InputStreamResponseListener();
         this.timeoutMillis = timeoutMillis;
     }
 
     @Override
     public final Response.Listener getListener()
     {
+        return newListener();
+    }
+
+    @Override
+    public final Response.Listener newListener()
+    {
+        this.listener = new InputStreamResponseListener();
         return this.listener;
     }
 
@@ -48,6 +54,6 @@ public class InputStreamJetty92ResponseEntityReader
         }
     }
 
-    private final InputStreamResponseListener listener;
+    private InputStreamResponseListener listener;
     private final long timeoutMillis;
 }

--- a/embulk-util-retryhelper-jetty92/src/main/java/org/embulk/util/retryhelper/jetty92/Jetty92ResponseReader.java
+++ b/embulk-util-retryhelper-jetty92/src/main/java/org/embulk/util/retryhelper/jetty92/Jetty92ResponseReader.java
@@ -3,14 +3,34 @@ package org.embulk.util.retryhelper.jetty92;
 import org.eclipse.jetty.client.api.Response;
 
 /**
- * Jetty92ResponseReader defines methods that read (understand) Jetty 9.3's response through {@code Listener}s.
+ * Jetty92ResponseReader defines methods that read (understand) Jetty 9.3's response
+ * through {@link org.eclipse.jetty.client.api.Response.Listener}s.
  *
- * Find some predefined {@code Jetty92ResponseReader}s such as {@code StringJetty92ResponseEntityReader}.
+ * Find some predefined {@code Jetty92ResponseReader}s such as {@link StringJetty92ResponseEntityReader}.
  */
 public interface Jetty92ResponseReader<T>
 {
+    /**
+     * @return {@link Response.Listener}
+     * @deprecated Use {@link #newListener()} instead.
+     */
+    @Deprecated
     Response.Listener getListener();
+
+    /**
+     * Obtains a new listener per request.
+     * Make sure it is called before reading the response. I.e., it must be called on per-request basis.
+     * @return {@link Response.Listener}
+     */
+    Response.Listener newListener();
+
+    /**
+     * @return Response as headers not waiting for contents.
+     * @throws Exception
+     */
     Response getResponse() throws Exception;
+
     T readResponseContent() throws Exception;
+
     String readResponseContentInString() throws Exception;
 }

--- a/embulk-util-retryhelper-jetty92/src/main/java/org/embulk/util/retryhelper/jetty92/StringJetty92ResponseEntityReader.java
+++ b/embulk-util-retryhelper-jetty92/src/main/java/org/embulk/util/retryhelper/jetty92/StringJetty92ResponseEntityReader.java
@@ -9,18 +9,27 @@ import com.google.common.io.CharStreams;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.util.InputStreamResponseListener;
 
+/**
+ * Response reader of http response.
+ */
 public class StringJetty92ResponseEntityReader
         implements Jetty92ResponseReader<String>
 {
     public StringJetty92ResponseEntityReader(long timeoutMillis)
     {
-        this.listener = new InputStreamResponseListener();
         this.timeoutMillis = timeoutMillis;
     }
 
     @Override
     public final Response.Listener getListener()
     {
+        return newListener();
+    }
+
+    @Override
+    public final Response.Listener newListener()
+    {
+        this.listener = new InputStreamResponseListener();
         return this.listener;
     }
 
@@ -48,6 +57,6 @@ public class StringJetty92ResponseEntityReader
         return this.readResponseContent();
     }
 
-    private final InputStreamResponseListener listener;
+    private InputStreamResponseListener listener;
     private final long timeoutMillis;
 }

--- a/embulk-util-retryhelper-jetty92/src/test/java/org/embulk/util/retryhelper/jetty92/Jetty92RetryHelperTest.java
+++ b/embulk-util-retryhelper-jetty92/src/test/java/org/embulk/util/retryhelper/jetty92/Jetty92RetryHelperTest.java
@@ -1,0 +1,102 @@
+package org.embulk.util.retryhelper.jetty92;
+
+import com.sun.net.httpserver.HttpServer;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.http.HttpMethod;
+import org.embulk.EmbulkTestRuntime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Jetty92RetryHelperTest
+{
+    @Rule
+    public final EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    private HttpServer httpServer;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        httpServer = HttpServer.create(new InetSocketAddress(8087), 0);
+        httpServer.createContext("/test", exchange -> {
+            byte[] response = "{\"success\": true}".getBytes();
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        httpServer.start();
+    }
+
+    @After
+    public void tearDown()
+    {
+        httpServer.stop(1);
+    }
+
+    @Test
+    public void requestWithRetry() throws Exception
+    {
+        int maxRetry = 3;
+
+        Jetty92RetryHelper retryHelper = new Jetty92RetryHelper(maxRetry,
+                10000,
+                10000,
+                new DefaultJetty92ClientCreator(1000, 10000));
+
+        String responseBody = retryHelper.requestWithRetry(
+                new StringJetty92ResponseEntityReader(10000),
+                new Jetty92SingleRequester()
+                {
+                    int retryCnt = 0;
+
+                    @Override
+                    public void requestOnce(HttpClient client, Response.Listener responseListener)
+                    {
+                        Request req;
+
+                        if (retryCnt < 1) {
+                            req = client.newRequest("http://localhost:8087/atest");
+                        } else {
+                            req = client.newRequest("http://localhost:8087/test");
+                        }
+                        retryCnt++;
+                        req.timeout(10000, TimeUnit.MILLISECONDS)
+                                .idleTimeout(10000, TimeUnit.MILLISECONDS)
+                                .method(HttpMethod.GET)
+                                .send(responseListener);
+                    }
+
+                    @Override
+                    protected boolean isResponseStatusToRetry(Response response)
+                    {
+                        if (response.getStatus() == 404) {
+                            return true;
+                        }
+                        return false;
+                    }
+
+                    @Override
+                    protected boolean isExceptionToRetry(Exception exception)
+                    {
+                        return exception instanceof EOFException || exception instanceof TimeoutException;
+                    }
+                });
+
+        assertTrue(!responseBody.isEmpty());
+        assertEquals("{\"success\": true}", responseBody);
+    }
+}

--- a/embulk-util-retryhelper-jetty93/src/main/java/org/embulk/util/retryhelper/jetty93/InputStreamJetty93ResponseEntityReader.java
+++ b/embulk-util-retryhelper-jetty93/src/main/java/org/embulk/util/retryhelper/jetty93/InputStreamJetty93ResponseEntityReader.java
@@ -21,6 +21,13 @@ public class InputStreamJetty93ResponseEntityReader
     @Override
     public final Response.Listener getListener()
     {
+        return newListener();
+    }
+
+    @Override
+    public final Response.Listener newListener()
+    {
+        this.listener = new InputStreamResponseListener();
         return this.listener;
     }
 
@@ -48,6 +55,6 @@ public class InputStreamJetty93ResponseEntityReader
         }
     }
 
-    private final InputStreamResponseListener listener;
+    private InputStreamResponseListener listener;
     private final long timeoutMillis;
 }

--- a/embulk-util-retryhelper-jetty93/src/main/java/org/embulk/util/retryhelper/jetty93/Jetty93ResponseReader.java
+++ b/embulk-util-retryhelper-jetty93/src/main/java/org/embulk/util/retryhelper/jetty93/Jetty93ResponseReader.java
@@ -9,8 +9,27 @@ import org.eclipse.jetty.client.api.Response;
  */
 public interface Jetty93ResponseReader<T>
 {
+    /**
+     * @return {@link Response.Listener}
+     * @deprecated Use {@link #newListener()} instead.
+     */
+    @Deprecated
     Response.Listener getListener();
+
+    /**
+     * Obtains a new listener per request.
+     * Make sure it is called before reading the response. I.e., it must be called on per-request basis.
+     * @return {@link Response.Listener}
+     */
+    Response.Listener newListener();
+
+    /**
+     * @return Response as headers not waiting for contents.
+     * @throws Exception
+     */
     Response getResponse() throws Exception;
+
     T readResponseContent() throws Exception;
+
     String readResponseContentInString() throws Exception;
 }

--- a/embulk-util-retryhelper-jetty93/src/main/java/org/embulk/util/retryhelper/jetty93/StringJetty93ResponseEntityReader.java
+++ b/embulk-util-retryhelper-jetty93/src/main/java/org/embulk/util/retryhelper/jetty93/StringJetty93ResponseEntityReader.java
@@ -21,6 +21,13 @@ public class StringJetty93ResponseEntityReader
     @Override
     public final Response.Listener getListener()
     {
+        return newListener();
+    }
+
+    @Override
+    public final Response.Listener newListener()
+    {
+        this.listener = new InputStreamResponseListener();
         return this.listener;
     }
 
@@ -48,6 +55,6 @@ public class StringJetty93ResponseEntityReader
         return this.readResponseContent();
     }
 
-    private final InputStreamResponseListener listener;
+    private InputStreamResponseListener listener;
     private final long timeoutMillis;
 }

--- a/embulk-util-retryhelper-jetty93/src/test/java/org/embulk/util/retryhelper/jetty92/Jetty93RetryHelperTest.java
+++ b/embulk-util-retryhelper-jetty93/src/test/java/org/embulk/util/retryhelper/jetty92/Jetty93RetryHelperTest.java
@@ -1,0 +1,106 @@
+package org.embulk.util.retryhelper.jetty92;
+
+import com.sun.net.httpserver.HttpServer;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.http.HttpMethod;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.util.retryhelper.jetty93.DefaultJetty93ClientCreator;
+import org.embulk.util.retryhelper.jetty93.Jetty93RetryHelper;
+import org.embulk.util.retryhelper.jetty93.Jetty93SingleRequester;
+import org.embulk.util.retryhelper.jetty93.StringJetty93ResponseEntityReader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Jetty93RetryHelperTest
+{
+    @Rule
+    public final EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    private HttpServer httpServer;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        httpServer = HttpServer.create(new InetSocketAddress(8087), 0);
+        httpServer.createContext("/test", exchange -> {
+            byte[] response = "{\"success\": true}".getBytes();
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        httpServer.start();
+    }
+
+    @After
+    public void tearDown()
+    {
+        httpServer.stop(1);
+    }
+
+    @Test
+    public void requestWithRetry() throws Exception
+    {
+        int maxRetry = 3;
+
+        Jetty93RetryHelper retryHelper = new Jetty93RetryHelper(maxRetry,
+                10000,
+                10000,
+                new DefaultJetty93ClientCreator(1000, 10000));
+
+        String responseBody = retryHelper.requestWithRetry(
+                new StringJetty93ResponseEntityReader(10000),
+                new Jetty93SingleRequester()
+                {
+                    int retryCnt = 0;
+
+                    @Override
+                    public void requestOnce(HttpClient client, Response.Listener responseListener)
+                    {
+                        Request req;
+
+                        if (retryCnt < 1) {
+                            req = client.newRequest("http://localhost:8087/atest");
+                        } else {
+                            req = client.newRequest("http://localhost:8087/test");
+                        }
+                        retryCnt++;
+                        req.timeout(10000, TimeUnit.MILLISECONDS)
+                                .idleTimeout(10000, TimeUnit.MILLISECONDS)
+                                .method(HttpMethod.GET)
+                                .send(responseListener);
+                    }
+
+                    @Override
+                    protected boolean isResponseStatusToRetry(Response response)
+                    {
+                        if (response.getStatus() == 404) {
+                            return true;
+                        }
+                        return false;
+                    }
+
+                    @Override
+                    protected boolean isExceptionToRetry(Exception exception)
+                    {
+                        return exception instanceof EOFException || exception instanceof TimeoutException;
+                    }
+                });
+
+        assertTrue(!responseBody.isEmpty());
+        assertEquals("{\"success\": true}", responseBody);
+    }
+}


### PR DESCRIPTION
Currently the listener in *ResponseEntityReader is initialized once and reused for every subsequent request. However the listener is to be used per request, otherwise it fails to read from the response stream (it is closed after each request).
This fix treats the listener per request and renames (deprecates for now) `getListener` to `newListener` to give an idea to the developer that it creates a new listener.