### PR TITLE
Remove JacksonTaskReportRecordBuffer#resumeFromTaskReport to remove calling TaskReport#getAttributes

### DIFF
--- a/embulk-output-example/src/main/java/org/embulk/output/example/ExampleOutputPluginDelegate.java
+++ b/embulk-output-example/src/main/java/org/embulk/output/example/ExampleOutputPluginDelegate.java
@@ -92,7 +92,14 @@ public class ExampleOutputPluginDelegate
     {
         ArrayNode records = JsonNodeFactory.instance.arrayNode();
         for (TaskReport taskReport : taskReports) {
-            records.addAll(JacksonTaskReportRecordBuffer.resumeFromTaskReport(taskReport, "records"));
+            final List<?> reportRecords = taskReport.get(List.class, "records");
+            for (final Object reportRecord : reportRecords) {
+                if (reportRecord instanceof JsonNode) {
+                    records.add((JsonNode) reportRecord);
+                } else {
+                    throw new RuntimeException("TaskReport: \"record\" does not consist of JSON nodes.");
+                }
+            }
         }
 
         ObjectNode json = JsonNodeFactory.instance.objectNode();

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonTaskReportRecordBuffer.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonTaskReportRecordBuffer.java
@@ -56,31 +56,6 @@ public class JacksonTaskReportRecordBuffer
         return taskReport;
     }
 
-    public static List<JsonNode> resumeFromTaskReport(TaskReport taskReport, String attributeName)
-    {
-        Iterable<Map.Entry<String, JsonNode>> attributes = taskReport.getAttributes();
-
-        JsonNode foundAttribute = null;
-        for (Map.Entry<String, JsonNode> attribute : attributes) {
-            if (attribute.getKey().equals(attributeName)) {
-                foundAttribute = attribute.getValue();
-                break;
-            }
-        }
-        if (foundAttribute == null) {
-            throw new RuntimeException("FATAL: Unexpected format in TaskReport: " + attributeName + " not found.");
-        }
-        if (!foundAttribute.isArray()) {
-            throw new RuntimeException("FATAL: Unexpected format in TaskReport: " + attributeName + " is not an array.");
-        }
-
-        ImmutableList.Builder<JsonNode> jsonNodesBuilder = ImmutableList.builder();
-        for (JsonNode record : foundAttribute) {
-            jsonNodesBuilder.add(record);
-        }
-        return jsonNodesBuilder.build();
-    }
-
     private final ArrayDeque<ObjectNode> records;
     private final String attributeName;
 }


### PR DESCRIPTION
`DataSource#getAttributes` has been removed from `embulk-core` / `embulk-api` since `v0.10.2`. Anyone should no longer call it.

On the other hand, no any plugin is calling `JacksonTaskReportRecordBuffer#resumeFromTaskReport` as far as the maintainers of this library looked for. It should be okay just to remove it.