### PR TITLE
Remove use of Guava

### DIFF
--- a/embulk-input-example_jetty93/src/main/java/org/embulk/input/example_jetty93/ExampleJetty93InputPluginDelegate.java
+++ b/embulk-input-example_jetty93/src/main/java/org/embulk/input/example_jetty93/ExampleJetty93InputPluginDelegate.java
@@ -23,8 +23,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import com.google.common.io.CharStreams;
-
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.client.api.ContentResponse;
 

--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginBaseUnsafe.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginBaseUnsafe.java
@@ -16,7 +16,6 @@
 
 package org.embulk.base.restclient;
 
-import com.google.common.base.Preconditions;
 import java.util.List;
 import org.embulk.base.restclient.record.ValueLocator;
 import org.embulk.config.ConfigDiff;
@@ -123,11 +122,11 @@ public class RestClientInputPluginBaseUnsafe<T extends RestClientInputTaskBase>
 
         try (final PageBuilder pageBuilder = new PageBuilder(Exec.getBufferAllocator(), schema, output)) {
             // When failing around |PageBuidler| in |ingestServiceData|, |pageBuilder.finish()| should not be called.
-            final TaskReport taskReport = Preconditions.checkNotNull(this.serviceDataIngester.ingestServiceData(
-                    task,
-                    serviceResponseMapper.createRecordImporter(),
-                    taskIndex,
-                    pageBuilder));
+            final TaskReport taskReport = this.serviceDataIngester.ingestServiceData(
+                    task, serviceResponseMapper.createRecordImporter(), taskIndex, pageBuilder);
+            if (taskReport == null) {
+                throw new NullPointerException("TaskReport is unexpectedly null.");
+            }
             pageBuilder.finish();
             return taskReport;
         }

--- a/src/main/java/org/embulk/base/restclient/ServiceRequestMapper.java
+++ b/src/main/java/org/embulk/base/restclient/ServiceRequestMapper.java
@@ -16,11 +16,13 @@
 
 package org.embulk.base.restclient;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ListMultimap;
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.embulk.base.restclient.record.EmbulkValueScope;
 import org.embulk.base.restclient.record.RecordExporter;
 import org.embulk.base.restclient.record.ValueLocator;
@@ -30,20 +32,24 @@ import org.embulk.base.restclient.record.ValueLocator;
  * how to place the values into the request.
  */
 public abstract class ServiceRequestMapper<T extends ValueLocator> {
-    protected ServiceRequestMapper(final ListMultimap<EmbulkValueScope, ColumnOptions<T>> map) {
-        this.map = ImmutableListMultimap.copyOf(map);
+    protected ServiceRequestMapper(final List<Map.Entry<EmbulkValueScope, ColumnOptions<T>>> map) {
+        final ArrayList<Map.Entry<EmbulkValueScope, ColumnOptions<T>>> built = new ArrayList<>();
+        for (final Map.Entry<EmbulkValueScope, ColumnOptions<T>> entry : map) {
+            built.add(new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue()));
+        }
+        this.map = Collections.unmodifiableList(built);
     }
 
     public abstract RecordExporter createRecordExporter();
 
     protected final Collection<Map.Entry<EmbulkValueScope, ColumnOptions<T>>> entries() {
-        return map.entries();
+        return this.map;
     }
 
     protected static class ColumnOptions<U extends ValueLocator> {
         public ColumnOptions(final U valueLocator) {
             this.valueLocator = valueLocator;
-            this.timestampFormat = Optional.absent();
+            this.timestampFormat = Optional.empty();
         }
 
         public ColumnOptions(final U valueLocator, final String timestampFormat) {
@@ -63,5 +69,5 @@ public abstract class ServiceRequestMapper<T extends ValueLocator> {
         private final Optional<String> timestampFormat;
     }
 
-    private final ImmutableListMultimap<EmbulkValueScope, ColumnOptions<T>> map;
+    private final List<Map.Entry<EmbulkValueScope, ColumnOptions<T>>> map;
 }

--- a/src/main/java/org/embulk/base/restclient/jackson/StringJsonParser.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/StringJsonParser.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Throwables;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import org.embulk.spi.DataException;
 
 public class StringJsonParser {
@@ -55,7 +55,7 @@ public class StringJsonParser {
         try {
             return mapper.readTree(jsonText);
         } catch (final IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/src/test/java/org/embulk/base/restclient/NoNullsRestClientPageOutputTest.java
+++ b/src/test/java/org/embulk/base/restclient/NoNullsRestClientPageOutputTest.java
@@ -19,7 +19,6 @@ package org.embulk.base.restclient;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import org.embulk.EmbulkTestRuntime;
@@ -70,8 +69,10 @@ public class NoNullsRestClientPageOutputTest {
         final PluginTask task = config.loadConfig(PluginTask.class);
         this.plugin.transaction(config, schema, 0, new OutputPlugin.Control() {
                 @Override
-                public List<TaskReport> run(TaskSource taskSource) {
-                    return Lists.newArrayList(Exec.newTaskReport());
+                public List<TaskReport> run(final TaskSource taskSource) {
+                    final ArrayList<TaskReport> newList = new ArrayList<>();
+                    newList.add(Exec.newTaskReport());
+                    return newList;
                 }
             });
         final TransactionalPageOutput output = this.plugin.open(task.dump(), schema, 0);
@@ -101,8 +102,10 @@ public class NoNullsRestClientPageOutputTest {
         final PluginTask task = config.loadConfig(PluginTask.class);
         this.plugin.transaction(config, schema, 0, new OutputPlugin.Control() {
                 @Override
-                public List<TaskReport> run(TaskSource taskSource) {
-                    return Lists.newArrayList(Exec.newTaskReport());
+                public List<TaskReport> run(final TaskSource taskSource) {
+                    final ArrayList<TaskReport> newList = new ArrayList<>();
+                    newList.add(Exec.newTaskReport());
+                    return newList;
                 }
             });
         final TransactionalPageOutput output = this.plugin.open(task.dump(), schema, 0);

--- a/src/test/java/org/embulk/base/restclient/OutputTestRecordBuffer.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestRecordBuffer.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.google.common.base.Throwables;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import org.embulk.base.restclient.OutputTestPluginDelegate.PluginTask;
 import org.embulk.base.restclient.jackson.JacksonServiceRecord;
 import org.embulk.base.restclient.record.RecordBuffer;
@@ -54,7 +54,7 @@ public class OutputTestRecordBuffer extends RecordBuffer {
         } catch (final ClassCastException ex) {
             throw new RuntimeException(ex);
         } catch (final IOException ex) {
-            throw Throwables.propagate(ex);
+            throw new UncheckedIOException(ex);
         }
     }
 

--- a/src/test/java/org/embulk/base/restclient/OutputTestUtils.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestUtils.java
@@ -16,7 +16,9 @@
 
 package org.embulk.base.restclient;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.embulk.config.ConfigSource;
 import org.embulk.spi.Exec;
 import org.embulk.spi.Schema;
@@ -34,17 +36,17 @@ class OutputTestUtils {
                 .set("parser", parserConfigJson());
     }
 
-    private ImmutableMap<String, Object> inputConfigJson() {
-        final ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
+    private Map<String, Object> inputConfigJson() {
+        final HashMap<String, Object> builder = new HashMap<>();
         builder.put("type", "file");
         builder.put("path_prefix", JSON_PATH_PREFIX);
         builder.put("last_path", "");
-        return builder.build();
+        return Collections.unmodifiableMap(builder);
     }
 
-    private ImmutableMap<String, Object> parserConfigJson() {
-        final ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
-        return builder.build();
+    private Map<String, Object> parserConfigJson() {
+        final HashMap<String, Object> builder = new HashMap<>();
+        return Collections.unmodifiableMap(builder);
     }
 
     Schema jsonSchema() {

--- a/src/test/java/org/embulk/base/restclient/RestClientPageOutputTest.java
+++ b/src/test/java/org/embulk/base/restclient/RestClientPageOutputTest.java
@@ -19,7 +19,6 @@ package org.embulk.base.restclient;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import org.embulk.EmbulkTestRuntime;
@@ -71,7 +70,9 @@ public class RestClientPageOutputTest {
         this.plugin.transaction(config, schema, 0, new OutputPlugin.Control() {
                 @Override
                 public List<TaskReport> run(final TaskSource taskSource) {
-                    return Lists.newArrayList(Exec.newTaskReport());
+                    final ArrayList<TaskReport> newList = new ArrayList<>();
+                    newList.add(Exec.newTaskReport());
+                    return newList;
                 }
             });
         final TransactionalPageOutput output = this.plugin.open(task.dump(), schema, 0);
@@ -103,7 +104,9 @@ public class RestClientPageOutputTest {
         this.plugin.transaction(config, schema, 0, new OutputPlugin.Control() {
                 @Override
                 public List<TaskReport> run(final TaskSource taskSource) {
-                    return Lists.newArrayList(Exec.newTaskReport());
+                    final ArrayList<TaskReport> newList = new ArrayList<>();
+                    newList.add(Exec.newTaskReport());
+                    return newList;
                 }
             });
         final TransactionalPageOutput output = plugin.open(task.dump(), schema, 0);

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
@@ -19,7 +19,6 @@ package org.embulk.input.shopify;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Strings;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -97,15 +96,15 @@ public class ShopifyInputPluginDelegate implements RestClientInputPluginDelegate
 
     @Override  // Overridden from |InputTaskValidatable|
     public void validateInputTask(final PluginTask task) {
-        if (Strings.isNullOrEmpty(task.getApiKey())) {
+        if (task.getApiKey() == null || task.getApiKey().isEmpty()) {
             throw new ConfigException("'apikey' must not be null or empty string.");
         }
 
-        if (Strings.isNullOrEmpty(task.getPassword())) {
+        if (task.getPassword() == null || task.getPassword().isEmpty()) {
             throw new ConfigException("'password' must not be null or empty string.");
         }
 
-        if (Strings.isNullOrEmpty(task.getStoreName())) {
+        if (task.getStoreName() == null || task.getStoreName().isEmpty()) {
             throw new ConfigException("'store_name' must not be null or empty string.");
         }
     }


### PR DESCRIPTION
As described in https://dev.embulk.org/topics/catchup-with-v0.10.html, it is nice for a plugin *not* to use Guava in it (not mandatory, but better). The use of Guava in `embulk-base-restclient` is not very essential, which can be removed.