### PR TITLE
Process timestamp formatting and parsing with embulk-util-timestamp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.jfrog.bintray" version "1.8.4"
     id "java"
+    id "java-library"
     id "maven" // install jar files to the local repo: $ gradle install
     id "maven-publish"
     id "checkstyle"
@@ -30,6 +31,8 @@ repositories {
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.5"
     compileOnly "org.embulk:embulk-core:0.10.5"
+
+    api "org.embulk:embulk-util-timestamp:0.2.0"
 
     testCompile "junit:junit:4.13"
     testCompile "org.embulk:embulk-api:0.10.5"

--- a/embulk-input-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -5,6 +5,8 @@ javax.annotation:javax.annotation-api:1.2
 javax.ws.rs:javax.ws.rs-api:2.0.1
 org.embulk:embulk-util-retryhelper-jaxrs:0.8.0
 org.embulk:embulk-util-retryhelper:0.8.0
+org.embulk:embulk-util-rubytime:0.3.0
+org.embulk:embulk-util-timestamp:0.2.0
 org.glassfish.hk2.external:aopalliance-repackaged:2.5.0-b32
 org.glassfish.hk2.external:javax.inject:2.5.0-b32
 org.glassfish.hk2:hk2-api:2.5.0-b32

--- a/embulk-input-example_jetty93/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-example_jetty93/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,3 +7,5 @@ org.eclipse.jetty:jetty-io:9.3.16.v20170120
 org.eclipse.jetty:jetty-util:9.3.16.v20170120
 org.embulk:embulk-util-retryhelper-jetty93:0.8.0
 org.embulk:embulk-util-retryhelper:0.8.0
+org.embulk:embulk-util-rubytime:0.3.0
+org.embulk:embulk-util-timestamp:0.2.0

--- a/embulk-output-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-output-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -5,6 +5,8 @@ javax.annotation:javax.annotation-api:1.2
 javax.ws.rs:javax.ws.rs-api:2.0.1
 org.embulk:embulk-util-retryhelper-jaxrs:0.8.0
 org.embulk:embulk-util-retryhelper:0.8.0
+org.embulk:embulk-util-rubytime:0.3.0
+org.embulk:embulk-util-timestamp:0.2.0
 org.glassfish.hk2.external:aopalliance-repackaged:2.5.0-b32
 org.glassfish.hk2.external:javax.inject:2.5.0-b32
 org.glassfish.hk2:hk2-api:2.5.0-b32

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -21,6 +21,7 @@ org.apache.bval:bval-jsr303:0.5
 org.apache.commons:commons-lang3:3.4
 org.embulk:embulk-api:0.10.5
 org.embulk:embulk-core:0.10.5
+org.embulk:embulk-util-timestamp:0.2.0
 org.jruby:jruby-complete:9.1.15.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.12

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,3 +1,5 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+org.embulk:embulk-util-rubytime:0.3.0
+org.embulk:embulk-util-timestamp:0.2.0

--- a/src/main/java/org/embulk/base/restclient/TimestampServiceDataSplitter.java
+++ b/src/main/java/org/embulk/base/restclient/TimestampServiceDataSplitter.java
@@ -16,22 +16,22 @@
 
 package org.embulk.base.restclient;
 
+import java.time.Instant;
 import org.embulk.spi.Schema;
-import org.embulk.spi.time.Timestamp;
 
 public abstract class TimestampServiceDataSplitter<T extends RestClientInputTaskBase> extends ServiceDataSplitter<T> {
     @Override
     public final int numberToSplitWithHintingInTask(final T taskToHint) {
-        final Timestamp beginningOfOverall = this.getBeginningOfOverall(taskToHint);
-        final Timestamp endingOfOverall = this.getEndingOfOverall(taskToHint);
+        final Instant beginningOfOverall = this.getBeginningOfOverall(taskToHint);
+        final Instant endingOfOverall = this.getEndingOfOverall(taskToHint);
         final SplitCalculator calculator = this.getSplitCalculator(taskToHint);
         return calculator.calculateNumberToSplit(beginningOfOverall, endingOfOverall);
     }
 
     @Override
     public final void hintInEachSplitTask(final T taskToHint, final Schema schema, final int taskIndex) {
-        final Timestamp beginningOfOverall = this.getBeginningOfOverall(taskToHint);
-        final Timestamp endingOfOverall = this.getEndingOfOverall(taskToHint);
+        final Instant beginningOfOverall = this.getBeginningOfOverall(taskToHint);
+        final Instant endingOfOverall = this.getEndingOfOverall(taskToHint);
         final SplitCalculator calculator = this.getSplitCalculator(taskToHint);
 
         this.setTimestampsOfEachTask(
@@ -41,16 +41,16 @@ public abstract class TimestampServiceDataSplitter<T extends RestClientInputTask
     }
 
     public abstract static class SplitCalculator {
-        public abstract int calculateNumberToSplit(Timestamp beginning, Timestamp ending);
+        public abstract int calculateNumberToSplit(Instant beginning, Instant ending);
 
-        public abstract Timestamp calculateBeginningOfEachTask(
-                Timestamp beginningOfOverall,
-                Timestamp endingOfOverall,
+        public abstract Instant calculateBeginningOfEachTask(
+                Instant beginningOfOverall,
+                Instant endingOfOverall,
                 int taskIndex);
 
-        public abstract Timestamp calculateEndingOfEachTask(
-                Timestamp beginningOfOverall,
-                Timestamp endingOfOverall,
+        public abstract Instant calculateEndingOfEachTask(
+                Instant beginningOfOverall,
+                Instant endingOfOverall,
                 int taskIndex);
     }
 
@@ -62,7 +62,7 @@ public abstract class TimestampServiceDataSplitter<T extends RestClientInputTask
      * This method is to be implemented in plugin's concrete ServiceDataSplitter class.
      * Called only from |numberToSplitWithHintingInTask| and |hintInEachSplitTask|.
      */
-    protected abstract Timestamp getBeginningOfOverall(T task);
+    protected abstract Instant getBeginningOfOverall(T task);
 
     /**
      * Returns the overall endning time from the given Task.
@@ -70,7 +70,7 @@ public abstract class TimestampServiceDataSplitter<T extends RestClientInputTask
      * This method is to be implemented in plugin's concrete ServiceDataSplitter class.
      * Called only from |numberToSplitWithHintingInTask| and |hintInEachSplitTask|.
      */
-    protected abstract Timestamp getEndingOfOverall(T task);
+    protected abstract Instant getEndingOfOverall(T task);
 
     /**
      * Returns an appropriate SplitCalculator for the given Task.
@@ -86,5 +86,5 @@ public abstract class TimestampServiceDataSplitter<T extends RestClientInputTask
      * This method is to be implemented in plugin's concrete ServiceDataSplitter class.
      * Called only from |numberToSplitWithHintingInTask| and |hintInEachSplitTask|.
      */
-    protected abstract void setTimestampsOfEachTask(T task, Timestamp beginning, Timestamp ending);
+    protected abstract void setTimestampsOfEachTask(T task, Instant beginning, Instant ending);
 }

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceValue.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceValue.java
@@ -18,10 +18,10 @@ package org.embulk.base.restclient.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
+import java.time.Instant;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.spi.json.JsonParser;
-import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.time.TimestampParser;
+import org.embulk.util.timestamp.TimestampFormatter;
 import org.msgpack.value.Value;
 
 /**
@@ -90,8 +90,8 @@ public class JacksonServiceValue extends ServiceValue {
     }
 
     @Override
-    public Timestamp timestampValue(final TimestampParser timestampParser) {
-        return timestampParser.parse(value.asText());
+    public Instant timestampValue(final TimestampFormatter timestampFormatter) {
+        return timestampFormatter.parse(value.asText());
     }
 
     JsonNode getInternalJsonNode() {

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
@@ -22,7 +22,7 @@ import org.embulk.base.restclient.jackson.StringJsonParser;
 import org.embulk.base.restclient.record.SinglePageRecordReader;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
-import org.embulk.spi.time.TimestampFormatter;
+import org.embulk.util.timestamp.TimestampFormatter;
 
 public class JacksonAllInObjectScope extends JacksonObjectScopeBase {
     public JacksonAllInObjectScope() {

--- a/src/main/java/org/embulk/base/restclient/record/ServiceValue.java
+++ b/src/main/java/org/embulk/base/restclient/record/ServiceValue.java
@@ -16,9 +16,9 @@
 
 package org.embulk.base.restclient.record;
 
+import java.time.Instant;
 import org.embulk.spi.json.JsonParser;
-import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.time.TimestampParser;
+import org.embulk.util.timestamp.TimestampFormatter;
 import org.msgpack.value.Value;
 
 public abstract class ServiceValue {
@@ -34,5 +34,5 @@ public abstract class ServiceValue {
 
     public abstract String stringValue();
 
-    public abstract Timestamp timestampValue(TimestampParser timestampParser);
+    public abstract Instant timestampValue(TimestampFormatter timestampFormatter);
 }

--- a/src/main/java/org/embulk/base/restclient/record/SinglePageRecordReader.java
+++ b/src/main/java/org/embulk/base/restclient/record/SinglePageRecordReader.java
@@ -16,10 +16,10 @@
 
 package org.embulk.base.restclient.record;
 
+import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
-import org.embulk.spi.time.Timestamp;
 import org.msgpack.value.Value;
 
 /**
@@ -74,12 +74,12 @@ public class SinglePageRecordReader {
         return this.pageReader.getString(columnIndex);
     }
 
-    public Timestamp getTimestamp(final Column column) {
-        return this.pageReader.getTimestamp(column);
+    public Instant getTimestamp(final Column column) {
+        return this.pageReader.getTimestamp(column).getInstant();
     }
 
-    public Timestamp getTimestamp(final int columnIndex) {
-        return this.pageReader.getTimestamp(columnIndex);
+    public Instant getTimestamp(final int columnIndex) {
+        return this.pageReader.getTimestamp(columnIndex).getInstant();
     }
 
     public Value getJson(final Column column) {

--- a/src/main/java/org/embulk/base/restclient/record/values/TimestampValueImporter.java
+++ b/src/main/java/org/embulk/base/restclient/record/values/TimestampValueImporter.java
@@ -23,12 +23,14 @@ import org.embulk.base.restclient.record.ValueLocator;
 import org.embulk.spi.Column;
 import org.embulk.spi.DataException;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.time.TimestampParser;
+import org.embulk.spi.time.Timestamp;
+import org.embulk.util.timestamp.TimestampFormatter;
 
 public class TimestampValueImporter extends ValueImporter {
-    public TimestampValueImporter(final Column column, final ValueLocator valueLocator, final TimestampParser timestampParser) {
+    public TimestampValueImporter(
+            final Column column, final ValueLocator valueLocator, final TimestampFormatter timestampFormatter) {
         super(column, valueLocator);
-        this.timestampParser = timestampParser;
+        this.timestampFormatter = timestampFormatter;
     }
 
     @Override
@@ -38,7 +40,7 @@ public class TimestampValueImporter extends ValueImporter {
             if (value == null || value.isNull()) {
                 pageBuilder.setNull(getColumnToImport());
             } else {
-                pageBuilder.setTimestamp(getColumnToImport(), value.timestampValue(timestampParser));
+                pageBuilder.setTimestamp(getColumnToImport(), Timestamp.ofInstant(value.timestampValue(timestampFormatter)));
             }
         } catch (final Exception ex) {
             throw new DataException(
@@ -48,5 +50,5 @@ public class TimestampValueImporter extends ValueImporter {
         }
     }
 
-    private final TimestampParser timestampParser;
+    private final TimestampFormatter timestampFormatter;
 }

--- a/src/test/java/org/embulk/base/restclient/NoNullsRestClientPageOutputTest.java
+++ b/src/test/java/org/embulk/base/restclient/NoNullsRestClientPageOutputTest.java
@@ -19,6 +19,7 @@ package org.embulk.base.restclient;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.embulk.EmbulkTestRuntime;
@@ -112,7 +113,14 @@ public class NoNullsRestClientPageOutputTest {
 
         // id, long, timestamp, boolean, double, string
         final List<Page> pages = PageTestUtils.buildPage(
-                runtime.getBufferAllocator(), schema, 2L, 42L, Timestamp.ofEpochSecond(1509738161), true, 123.45, "embulk");
+                runtime.getBufferAllocator(),
+                schema,
+                2L,
+                42L,
+                Timestamp.ofInstant(Instant.ofEpochSecond(1509738161)),
+                true,
+                123.45,
+                "embulk");
         assertThat(pages.size(), is(1));
         for (final Page page : pages) {
             output.add(page);

--- a/src/test/java/org/embulk/base/restclient/OutputTestPluginDelegate.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestPluginDelegate.java
@@ -26,8 +26,7 @@ import org.embulk.config.ConfigDiff;
 import org.embulk.config.TaskReport;
 import org.embulk.spi.Exec;
 import org.embulk.spi.Schema;
-import org.embulk.spi.time.TimestampFormatter;
-import org.joda.time.DateTimeZone;
+import org.embulk.util.timestamp.TimestampFormatter;
 
 public class OutputTestPluginDelegate implements RestClientOutputPluginDelegate<OutputTestPluginDelegate.PluginTask> {
     OutputTestPluginDelegate(final boolean outputNulls) {
@@ -35,7 +34,7 @@ public class OutputTestPluginDelegate implements RestClientOutputPluginDelegate<
         this.outputNulls = outputNulls;
     }
 
-    public interface PluginTask extends RestClientOutputTaskBase, TimestampFormatter.Task {
+    public interface PluginTask extends RestClientOutputTaskBase {
     }
 
     @Override  // Overridden from |OutputTaskValidatable|
@@ -44,7 +43,8 @@ public class OutputTestPluginDelegate implements RestClientOutputPluginDelegate<
 
     @Override  // Overridden from |ServiceRequestMapperBuildable|
     public JacksonServiceRequestMapper buildServiceRequestMapper(final PluginTask task) {
-        final TimestampFormatter formatter = new TimestampFormatter("%Y-%m-%dT%H:%M:%S.%3N%z", DateTimeZone.forID("UTC"));
+        final TimestampFormatter formatter =
+                TimestampFormatter.builder("%Y-%m-%dT%H:%M:%S.%3N%z", true).build();
 
         return JacksonServiceRequestMapper.builder()
                 .add(new JacksonAllInObjectScope(formatter, this.outputNulls), new JacksonTopLevelValueLocator("record"))

--- a/src/test/java/org/embulk/base/restclient/RestClientPageOutputTest.java
+++ b/src/test/java/org/embulk/base/restclient/RestClientPageOutputTest.java
@@ -19,6 +19,7 @@ package org.embulk.base.restclient;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.embulk.EmbulkTestRuntime;
@@ -113,7 +114,14 @@ public class RestClientPageOutputTest {
 
         // id, long, timestamp, boolean, double, string
         final List<Page> pages = PageTestUtils.buildPage(
-                runtime.getBufferAllocator(), schema, 2L, 42L, Timestamp.ofEpochSecond(1509738161), true, 123.45, "embulk");
+                runtime.getBufferAllocator(),
+                schema,
+                2L,
+                42L,
+                Timestamp.ofInstant(Instant.ofEpochSecond(1509738161)),
+                true,
+                123.45,
+                "embulk");
         assertThat(pages.size(), is(1));
         for (final Page page : pages) {
             output.add(page);


### PR DESCRIPTION
As described in https://dev.embulk.org/topics/catchup-with-v0.10.html, `embulk-core`'s `TimestampFormatter` and `TimestampParser` are no longer recommended. Using [`embulk-util-timestamp`](https://dev.embulk.org/embulk-util-timestamp/) on the plugin side, instead.