### PR TITLE
Use Jackson ObjectMapper to create ArrayNode and ObjectNode

### DIFF
--- a/embulk-output-example/src/main/java/org/embulk/output/example/ExampleOutputPluginDelegate.java
+++ b/embulk-output-example/src/main/java/org/embulk/output/example/ExampleOutputPluginDelegate.java
@@ -25,9 +25,9 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -106,7 +106,7 @@ public class ExampleOutputPluginDelegate
                                       int taskIndex,
                                       List<TaskReport> taskReports)
     {
-        ArrayNode records = JsonNodeFactory.instance.arrayNode();
+        ArrayNode records = OBJECT_MAPPER.createArrayNode();
         for (TaskReport taskReport : taskReports) {
             final List<?> reportRecords = taskReport.get(List.class, "records");
             for (final Object reportRecord : reportRecords) {
@@ -118,7 +118,7 @@ public class ExampleOutputPluginDelegate
             }
         }
 
-        ObjectNode json = JsonNodeFactory.instance.objectNode();
+        ObjectNode json = OBJECT_MAPPER.createObjectNode();
         json.put("timestamp", Calendar.getInstance().getTime().getTime());
         json.set("records", records);
 
@@ -157,4 +157,6 @@ public class ExampleOutputPluginDelegate
                 }
             });
     }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 }

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceRecord.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceRecord.java
@@ -16,7 +16,7 @@
 
 package org.embulk.base.restclient.jackson;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
@@ -33,12 +33,12 @@ public class JacksonServiceRecord extends ServiceRecord {
 
     public static class Builder extends ServiceRecord.Builder {
         public Builder() {
-            this.node = JsonNodeFactory.instance.objectNode();
+            this.node = MAPPER.createObjectNode();
         }
 
         @Override
         public void reset() {
-            this.node = JsonNodeFactory.instance.objectNode();
+            this.node = MAPPER.createObjectNode();
         }
 
         @Override
@@ -66,6 +66,8 @@ public class JacksonServiceRecord extends ServiceRecord {
             this.reset();
             return built;
         }
+
+        private static final ObjectMapper MAPPER = new ObjectMapper();
 
         private ObjectNode node;
     }

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonAllInObjectScope.java
@@ -16,7 +16,7 @@
 
 package org.embulk.base.restclient.jackson.scope;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.embulk.base.restclient.jackson.StringJsonParser;
 import org.embulk.base.restclient.record.SinglePageRecordReader;
@@ -45,7 +45,7 @@ public class JacksonAllInObjectScope extends JacksonObjectScopeBase {
 
     @Override
     public ObjectNode scopeObject(final SinglePageRecordReader singlePageRecordReader) {
-        final ObjectNode resultObject = JsonNodeFactory.instance.objectNode();
+        final ObjectNode resultObject = OBJECT_MAPPER.createObjectNode();
 
         singlePageRecordReader.getSchema().visitColumns(new ColumnVisitor() {
                 @Override
@@ -114,6 +114,8 @@ public class JacksonAllInObjectScope extends JacksonObjectScopeBase {
             });
         return resultObject;
     }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final TimestampFormatter timestampFormatter;
     private final StringJsonParser jsonParser;

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonNewArrayScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonNewArrayScope.java
@@ -16,13 +16,15 @@
 
 package org.embulk.base.restclient.jackson.scope;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.embulk.base.restclient.record.SinglePageRecordReader;
 
 public class JacksonNewArrayScope extends JacksonArrayScopeBase {
     @Override
     public ArrayNode scopeArray(final SinglePageRecordReader singlePageRecordReader) {
-        return JsonNodeFactory.instance.arrayNode();
+        return OBJECT_MAPPER.createArrayNode();
     }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 }

--- a/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonNewObjectScope.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/scope/JacksonNewObjectScope.java
@@ -16,13 +16,15 @@
 
 package org.embulk.base.restclient.jackson.scope;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.embulk.base.restclient.record.SinglePageRecordReader;
 
 public class JacksonNewObjectScope extends JacksonObjectScopeBase {
     @Override
     public ObjectNode scopeObject(final SinglePageRecordReader singlePageRecordReader) {
-        return JsonNodeFactory.instance.objectNode();
+        return OBJECT_MAPPER.createObjectNode();
     }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 }

--- a/src/test/java/org/embulk/base/restclient/OutputTestRecordBuffer.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestRecordBuffer.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import org.embulk.base.restclient.OutputTestPluginDelegate.PluginTask;
@@ -38,7 +37,7 @@ public class OutputTestRecordBuffer extends RecordBuffer {
         this.mapper = new ObjectMapper()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, false);
-        this.records = JsonNodeFactory.instance.arrayNode();
+        this.records = OBJECT_MAPPER.createArrayNode();
     }
 
     @Override
@@ -75,6 +74,8 @@ public class OutputTestRecordBuffer extends RecordBuffer {
     public String toString() {
         return this.records.toString();
     }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private final String attributeName;


### PR DESCRIPTION
To generate Jackson `ArrayNode` and `ObjectNode`, `JsonNodeFactory.instance` is not very recommended. Using `ObjectMapper#create...` is more straightforward.