### PR TITLE
Declare dependencies explicitly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,20 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-api:0.10.5"
-    compileOnly "org.embulk:embulk-core:0.10.5"
+    compileOnly("org.embulk:embulk-api:0.10.5") {
+        exclude group: "*"
+    }
+    compileOnly("org.embulk:embulk-core:0.10.5") {
+        exclude group: "*"
+    }
 
+    // Excluding all transitive dependencies from embulk-api and embulk-core,
+    // and declaring necessary dependencies explicitly.
     api "org.embulk:embulk-util-timestamp:0.2.0"
+    api "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
+    api "com.fasterxml.jackson.core:jackson-core:2.6.7"
+    api "com.fasterxml.jackson.core:jackson-databind:2.6.7"
+    api "org.msgpack:msgpack-core:0.8.11"
 
     testImplementation "junit:junit:4.13"
     testImplementation "org.embulk:embulk-api:0.10.5"

--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,10 @@ publishing {
 
                 developers {
                     developer {
+                        name = "Muga Nishizawa"
+                        email = "muga.nishizawa@gmail.com"
+                    }
+                    developer {
                         name = "Dai MIKURUBE"
                         email = "dmikurube@treasure-data.com"
                     }

--- a/embulk-input-example/build.gradle
+++ b/embulk-input-example/build.gradle
@@ -40,6 +40,12 @@ embulkPlugin {
     mainClass = "org.embulk.input.example.ExampleInputPlugin"
     category = "input"
     type = "example"
+    ignoreConflicts = [
+        [ group: "com.fasterxml.jackson.core", module: "jackson-annotations" ],
+        [ group: "com.fasterxml.jackson.core", module: "jackson-core" ],
+        [ group: "com.fasterxml.jackson.core", module: "jackson-databind" ],
+        [ group: "org.msgpack", module: "msgpack-core" ],
+    ]
 }
 
 gem {

--- a/embulk-input-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,6 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
 javax.annotation:javax.annotation-api:1.2
 javax.ws.rs:javax.ws.rs-api:2.0.1
 org.embulk:embulk-util-retryhelper-jaxrs:0.8.0
@@ -17,3 +20,4 @@ org.glassfish.jersey.bundles.repackaged:jersey-guava:2.25.1
 org.glassfish.jersey.core:jersey-client:2.25.1
 org.glassfish.jersey.core:jersey-common:2.25.1
 org.javassist:javassist:3.20.0-GA
+org.msgpack:msgpack-core:0.8.11

--- a/embulk-input-example_jetty93/build.gradle
+++ b/embulk-input-example_jetty93/build.gradle
@@ -37,6 +37,12 @@ embulkPlugin {
     mainClass = "org.embulk.input.example_jetty93.ExampleJetty93InputPlugin"
     category = "input"
     type = "example_jetty93"
+    ignoreConflicts = [
+        [ group: "com.fasterxml.jackson.core", module: "jackson-annotations" ],
+        [ group: "com.fasterxml.jackson.core", module: "jackson-core" ],
+        [ group: "com.fasterxml.jackson.core", module: "jackson-databind" ],
+        [ group: "org.msgpack", module: "msgpack-core" ],
+    ]
 }
 
 gem {

--- a/embulk-input-example_jetty93/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-example_jetty93/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,6 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
 org.eclipse.jetty:jetty-client:9.3.16.v20170120
 org.eclipse.jetty:jetty-http:9.3.16.v20170120
 org.eclipse.jetty:jetty-io:9.3.16.v20170120
@@ -9,3 +12,4 @@ org.embulk:embulk-util-retryhelper-jetty93:0.8.0
 org.embulk:embulk-util-retryhelper:0.8.0
 org.embulk:embulk-util-rubytime:0.3.0
 org.embulk:embulk-util-timestamp:0.2.0
+org.msgpack:msgpack-core:0.8.11

--- a/embulk-output-example/build.gradle
+++ b/embulk-output-example/build.gradle
@@ -39,6 +39,12 @@ embulkPlugin {
     mainClass = "org.embulk.output.example.ExampleOutputPlugin"
     category = "output"
     type = "example"
+    ignoreConflicts = [
+        [ group: "com.fasterxml.jackson.core", module: "jackson-annotations" ],
+        [ group: "com.fasterxml.jackson.core", module: "jackson-core" ],
+        [ group: "com.fasterxml.jackson.core", module: "jackson-databind" ],
+        [ group: "org.msgpack", module: "msgpack-core" ],
+    ]
 }
 
 gem {

--- a/embulk-output-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-output-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,6 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
 javax.annotation:javax.annotation-api:1.2
 javax.ws.rs:javax.ws.rs-api:2.0.1
 org.embulk:embulk-util-retryhelper-jaxrs:0.8.0
@@ -17,3 +20,4 @@ org.glassfish.jersey.bundles.repackaged:jersey-guava:2.25.1
 org.glassfish.jersey.core:jersey-client:2.25.1
 org.glassfish.jersey.core:jersey-common:2.25.1
 org.javassist:javassist:3.20.0-GA
+org.msgpack:msgpack-core:0.8.11

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,27 +1,10 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-aopalliance:aopalliance:1.0
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
-com.fasterxml.jackson.module:jackson-module-guice:2.6.7
-com.google.guava:guava:18.0
-com.google.inject.extensions:guice-multibindings:4.0
-com.google.inject:guice:4.0
-commons-beanutils:commons-beanutils-core:1.8.3
-javax.inject:javax.inject:1
-javax.validation:validation-api:1.1.0.Final
-joda-time:joda-time:2.9.2
-org.apache.bval:bval-core:0.5
-org.apache.bval:bval-jsr303:0.5
-org.apache.commons:commons-lang3:3.4
 org.embulk:embulk-api:0.10.5
 org.embulk:embulk-core:0.10.5
 org.embulk:embulk-util-timestamp:0.2.0
-org.jruby:jruby-complete:9.1.15.0
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,5 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
 org.embulk:embulk-util-rubytime:0.3.0
 org.embulk:embulk-util-timestamp:0.2.0
+org.msgpack:msgpack-core:0.8.11


### PR DESCRIPTION
As a library (not a plugin), it should have exact accurate dependencies. With this change, `<dependencies>` in its POM file would be like below :

```
  <dependencies>
    <dependency>
      <groupId>org.embulk</groupId>
      <artifactId>embulk-util-timestamp</artifactId>
      <version>0.2.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-annotations</artifactId>
      <version>2.6.7</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-core</artifactId>
      <version>2.6.7</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-databind</artifactId>
      <version>2.6.7</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.msgpack</groupId>
      <artifactId>msgpack-core</artifactId>
      <version>0.8.11</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
```
