### PR TITLE
Use embulk-util-config instead of embulk-core's config processor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 
     // Excluding all transitive dependencies from embulk-api and embulk-core,
     // and declaring necessary dependencies explicitly.
+    api "org.embulk:embulk-util-config:0.1.3"
     api "org.embulk:embulk-util-timestamp:0.2.1"
     api "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     api "com.fasterxml.jackson.core:jackson-core:2.6.7"

--- a/embulk-input-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -4,8 +4,11 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.annotation:javax.annotation-api:1.2
+javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1
+org.embulk:embulk-util-config:0.1.3
 org.embulk:embulk-util-retryhelper-jaxrs:0.8.0
 org.embulk:embulk-util-retryhelper:0.8.0
 org.embulk:embulk-util-rubytime:0.3.2

--- a/embulk-input-example/src/main/java/org/embulk/input/example/ExampleInputPlugin.java
+++ b/embulk-input-example/src/main/java/org/embulk/input/example/ExampleInputPlugin.java
@@ -17,12 +17,17 @@
 package org.embulk.input.example;
 
 import org.embulk.base.restclient.RestClientInputPluginBase;
+import org.embulk.util.config.ConfigMapperFactory;
 
 public class ExampleInputPlugin
         extends RestClientInputPluginBase<ExampleInputPluginDelegate.PluginTask>
 {
     public ExampleInputPlugin()
     {
-        super(ExampleInputPluginDelegate.PluginTask.class, new ExampleInputPluginDelegate());
+        super(CONFIG_MAPPER_FACTORY,
+              ExampleInputPluginDelegate.PluginTask.class,
+              new ExampleInputPluginDelegate(CONFIG_MAPPER_FACTORY));
     }
+
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 }

--- a/embulk-input-example/src/main/java/org/embulk/input/example/ExampleInputPluginDelegate.java
+++ b/embulk-input-example/src/main/java/org/embulk/input/example/ExampleInputPluginDelegate.java
@@ -25,13 +25,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.DataException;
-import org.embulk.spi.Exec;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.Schema;
 import org.embulk.spi.type.Types;
@@ -44,7 +41,9 @@ import org.embulk.base.restclient.jackson.JacksonServiceRecord;
 import org.embulk.base.restclient.jackson.JacksonServiceResponseMapper;
 import org.embulk.base.restclient.jackson.StringJsonParser;
 import org.embulk.base.restclient.record.RecordImporter;
-
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
+import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.retryhelper.jaxrs.JAXRSClientCreator;
 import org.embulk.util.retryhelper.jaxrs.JAXRSRetryHelper;
 import org.embulk.util.retryhelper.jaxrs.JAXRSSingleRequester;
@@ -56,6 +55,10 @@ import org.slf4j.LoggerFactory;
 public class ExampleInputPluginDelegate
         implements RestClientInputPluginDelegate<ExampleInputPluginDelegate.PluginTask>
 {
+    public ExampleInputPluginDelegate(final ConfigMapperFactory configMapperFactory) {
+        this.configMapperFactory = configMapperFactory;
+    }
+
     public interface PluginTask
             extends RestClientInputTaskBase
     {
@@ -92,7 +95,7 @@ public class ExampleInputPluginDelegate
     {
         // should implement for incremental data loading
         // consider |incremental| config here
-        return Exec.newConfigDiff();
+        return this.configMapperFactory.newConfigDiff();
     }
 
     @Override  // Overridden from |ServiceDataSplitterBuildable|
@@ -134,7 +137,7 @@ public class ExampleInputPluginDelegate
             }
         }
 
-        return Exec.newTaskReport();
+        return this.configMapperFactory.newTaskReport();
     }
 
     private ArrayNode extractArrayField(String content)
@@ -170,4 +173,6 @@ public class ExampleInputPluginDelegate
     }
 
     private final Logger logger = LoggerFactory.getLogger(ExampleInputPluginDelegate.class);
+
+    private final ConfigMapperFactory configMapperFactory;
 }

--- a/embulk-input-example_jetty93/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-example_jetty93/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -4,10 +4,13 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+javax.validation:validation-api:1.1.0.Final
 org.eclipse.jetty:jetty-client:9.3.16.v20170120
 org.eclipse.jetty:jetty-http:9.3.16.v20170120
 org.eclipse.jetty:jetty-io:9.3.16.v20170120
 org.eclipse.jetty:jetty-util:9.3.16.v20170120
+org.embulk:embulk-util-config:0.1.3
 org.embulk:embulk-util-retryhelper-jetty93:0.8.0
 org.embulk:embulk-util-retryhelper:0.8.0
 org.embulk:embulk-util-rubytime:0.3.2

--- a/embulk-input-example_jetty93/src/main/java/org/embulk/input/example_jetty93/ExampleJetty93InputPlugin.java
+++ b/embulk-input-example_jetty93/src/main/java/org/embulk/input/example_jetty93/ExampleJetty93InputPlugin.java
@@ -17,12 +17,17 @@
 package org.embulk.input.example_jetty93;
 
 import org.embulk.base.restclient.RestClientInputPluginBase;
+import org.embulk.util.config.ConfigMapperFactory;
 
 public class ExampleJetty93InputPlugin
         extends RestClientInputPluginBase<ExampleJetty93InputPluginDelegate.PluginTask>
 {
     public ExampleJetty93InputPlugin()
     {
-        super(ExampleJetty93InputPluginDelegate.PluginTask.class, new ExampleJetty93InputPluginDelegate());
+        super(CONFIG_MAPPER_FACTORY,
+              ExampleJetty93InputPluginDelegate.PluginTask.class,
+              new ExampleJetty93InputPluginDelegate(CONFIG_MAPPER_FACTORY));
     }
+
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 }

--- a/embulk-input-example_jetty93/src/main/java/org/embulk/input/example_jetty93/ExampleJetty93InputPluginDelegate.java
+++ b/embulk-input-example_jetty93/src/main/java/org/embulk/input/example_jetty93/ExampleJetty93InputPluginDelegate.java
@@ -26,13 +26,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.client.api.ContentResponse;
 
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.TaskSource;
 import org.embulk.config.TaskReport;
 import org.embulk.spi.DataException;
-import org.embulk.spi.Exec;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.Schema;
 import org.embulk.spi.type.Types;
@@ -45,7 +42,9 @@ import org.embulk.base.restclient.jackson.JacksonServiceRecord;
 import org.embulk.base.restclient.jackson.JacksonServiceResponseMapper;
 import org.embulk.base.restclient.jackson.StringJsonParser;
 import org.embulk.base.restclient.record.RecordImporter;
-
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
+import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.retryhelper.jetty93.DefaultJetty93ClientCreator;
 import org.embulk.util.retryhelper.jetty93.Jetty93RetryHelper;
 import org.embulk.util.retryhelper.jetty93.Jetty93SingleRequester;
@@ -57,6 +56,10 @@ import org.slf4j.LoggerFactory;
 public class ExampleJetty93InputPluginDelegate
         implements RestClientInputPluginDelegate<ExampleJetty93InputPluginDelegate.PluginTask>
 {
+    public ExampleJetty93InputPluginDelegate(final ConfigMapperFactory configMapperFactory) {
+        this.configMapperFactory = configMapperFactory;
+    }
+
     public interface PluginTask
             extends RestClientInputTaskBase
     {
@@ -93,7 +96,7 @@ public class ExampleJetty93InputPluginDelegate
     {
         // should implement for incremental data loading
         // consider |incremental| config here
-        return Exec.newConfigDiff();
+        return this.configMapperFactory.newConfigDiff();
     }
 
     @Override  // Overridden from |ServiceDataSplitterBuildable|
@@ -130,7 +133,7 @@ public class ExampleJetty93InputPluginDelegate
             }
         }
 
-        return Exec.newTaskReport();
+        return this.configMapperFactory.newTaskReport();
     }
 
     private ArrayNode extractArrayField(String content)
@@ -169,4 +172,6 @@ public class ExampleJetty93InputPluginDelegate
     }
 
     private final Logger logger = LoggerFactory.getLogger(ExampleJetty93InputPluginDelegate.class);
+
+    private final ConfigMapperFactory configMapperFactory;
 }

--- a/embulk-output-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-output-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -4,8 +4,11 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.annotation:javax.annotation-api:1.2
+javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1
+org.embulk:embulk-util-config:0.1.3
 org.embulk:embulk-util-retryhelper-jaxrs:0.8.0
 org.embulk:embulk-util-retryhelper:0.8.0
 org.embulk:embulk-util-rubytime:0.3.2

--- a/embulk-output-example/src/main/java/org/embulk/output/example/ExampleOutputPlugin.java
+++ b/embulk-output-example/src/main/java/org/embulk/output/example/ExampleOutputPlugin.java
@@ -17,12 +17,17 @@
 package org.embulk.output.example;
 
 import org.embulk.base.restclient.RestClientOutputPluginBase;
+import org.embulk.util.config.ConfigMapperFactory;
 
 public class ExampleOutputPlugin
         extends RestClientOutputPluginBase<ExampleOutputPluginDelegate.PluginTask>
 {
     public ExampleOutputPlugin()
     {
-        super(ExampleOutputPluginDelegate.PluginTask.class, new ExampleOutputPluginDelegate());
+        super(CONFIG_MAPPER_FACTORY,
+              ExampleOutputPluginDelegate.PluginTask.class,
+              new ExampleOutputPluginDelegate(CONFIG_MAPPER_FACTORY));
     }
+
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 }

--- a/embulk-output-example/src/main/java/org/embulk/output/example/ExampleOutputPluginDelegate.java
+++ b/embulk-output-example/src/main/java/org/embulk/output/example/ExampleOutputPluginDelegate.java
@@ -29,11 +29,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.TaskReport;
-import org.embulk.spi.Exec;
 import org.embulk.spi.Schema;
 
 import org.embulk.base.restclient.RestClientOutputPluginDelegate;
@@ -46,7 +43,9 @@ import org.embulk.base.restclient.jackson.scope.JacksonAllInObjectScope;
 import org.embulk.base.restclient.jackson.scope.JacksonDirectIntegerScope;
 import org.embulk.base.restclient.jackson.scope.JacksonDirectStringScope;
 import org.embulk.base.restclient.record.RecordBuffer;
-
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
+import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.retryhelper.jaxrs.JAXRSClientCreator;
 import org.embulk.util.retryhelper.jaxrs.JAXRSRetryHelper;
 import org.embulk.util.retryhelper.jaxrs.JAXRSSingleRequester;
@@ -55,6 +54,10 @@ import org.embulk.util.retryhelper.jaxrs.StringJAXRSResponseEntityReader;
 public class ExampleOutputPluginDelegate
     implements RestClientOutputPluginDelegate<ExampleOutputPluginDelegate.PluginTask>
 {
+    public ExampleOutputPluginDelegate(final ConfigMapperFactory configMapperFactory) {
+        this.configMapperFactory = configMapperFactory;
+    }
+
     public interface PluginTask
             extends RestClientOutputTaskBase
     {
@@ -135,7 +138,7 @@ public class ExampleOutputPluginDelegate
             push(retryHelper, json, task.getEndpoint());
         }
 
-        return Exec.newConfigDiff();
+        return this.configMapperFactory.newConfigDiff();
     }
 
     private String push(JAXRSRetryHelper retryHelper, final JsonNode json, final String endpoint)
@@ -159,4 +162,6 @@ public class ExampleOutputPluginDelegate
     }
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final ConfigMapperFactory configMapperFactory;
 }

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -7,5 +7,6 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 org.embulk:embulk-api:0.10.12
 org.embulk:embulk-core:0.10.12
 org.embulk:embulk-spi:0.10.12
+org.embulk:embulk-util-config:0.1.3
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -4,6 +4,9 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+javax.validation:validation-api:1.1.0.Final
+org.embulk:embulk-util-config:0.1.3
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11

--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginBase.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginBase.java
@@ -24,6 +24,7 @@ import org.embulk.config.TaskSource;
 import org.embulk.spi.InputPlugin;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
+import org.embulk.util.config.ConfigMapperFactory;
 
 /**
  * RestClientInputPluginBase is a base class of input plugin implementations.
@@ -40,13 +41,15 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase> extend
      * This constructor is designed to be called like {@code super(...);} as this class is to be inherited.
      */
     protected RestClientInputPluginBase(
+            final ConfigMapperFactory configMapperFactory,
             final Class<T> taskClass,
             final ConfigDiffBuildable<T> configDiffBuilder,
             final InputTaskValidatable<T> inputTaskValidator,
             final ServiceDataIngestable<T> serviceDataIngester,
             final ServiceDataSplitterBuildable<T> serviceDataSplitterBuilder,
             final ServiceResponseMapperBuildable<T> serviceResponseMapperBuilder) {
-        super(taskClass,
+        super(configMapperFactory,
+              taskClass,
               configDiffBuilder,
               inputTaskValidator,
               serviceDataIngester,
@@ -60,12 +63,14 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase> extend
      * This constructor is designed to be called like {@code super(...);} as this class is to be inherited.
      */
     protected RestClientInputPluginBase(
+            final ConfigMapperFactory configMapperFactory,
             final Class<T> taskClass,
             final ConfigDiffBuildable<T> configDiffBuilder,
             final InputTaskValidatable<T> inputTaskValidator,
             final ServiceDataIngestable<T> serviceDataIngester,
             final ServiceResponseMapperBuildable<T> serviceResponseMapperBuilder) {
-        super(taskClass,
+        super(configMapperFactory,
+              taskClass,
               configDiffBuilder,
               inputTaskValidator,
               serviceDataIngester,
@@ -77,8 +82,11 @@ public class RestClientInputPluginBase<T extends RestClientInputTaskBase> extend
      *
      * This constructor is designed to be called like {@code super(...);} as this class is to be inherited.
      */
-    protected RestClientInputPluginBase(final Class<T> taskClass, final RestClientInputPluginDelegate<T> delegate) {
-        super(taskClass, delegate, delegate, delegate, delegate, delegate);
+    protected RestClientInputPluginBase(
+            final ConfigMapperFactory configMapperFactory,
+            final Class<T> taskClass,
+            final RestClientInputPluginDelegate<T> delegate) {
+        super(configMapperFactory, taskClass, delegate, delegate, delegate, delegate, delegate);
     }
 
     @Override

--- a/src/main/java/org/embulk/base/restclient/RestClientOutputPluginBase.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientOutputPluginBase.java
@@ -24,6 +24,7 @@ import org.embulk.config.TaskSource;
 import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
+import org.embulk.util.config.ConfigMapperFactory;
 
 /**
  * RestClientOutputPluginBase is a base class of output plugin implementations.
@@ -40,12 +41,14 @@ public class RestClientOutputPluginBase<T extends RestClientOutputTaskBase> exte
      * This constructor is designed to be called like {@code super(...);} as this class is to be inherited.
      */
     protected RestClientOutputPluginBase(
+            final ConfigMapperFactory configMapperFactory,
             final Class<T> taskClass,
             final EmbulkDataEgestable<T> embulkDataEgester,
             final RecordBufferBuildable<T> recordBufferBuilder,
             final OutputTaskValidatable<T> outputTaskValidator,
             final ServiceRequestMapperBuildable<T> serviceRequestMapperBuilder) {
-        super(taskClass,
+        super(configMapperFactory,
+              taskClass,
               embulkDataEgester,
               recordBufferBuilder,
               outputTaskValidator,
@@ -57,8 +60,11 @@ public class RestClientOutputPluginBase<T extends RestClientOutputTaskBase> exte
      *
      * This constructor is designed to be called like {@code super(...);} as this class is to be inherited.
      */
-    protected RestClientOutputPluginBase(final Class<T> taskClass, final RestClientOutputPluginDelegate<T> delegate) {
-        super(taskClass, delegate, delegate, delegate, delegate);
+    protected RestClientOutputPluginBase(
+            final ConfigMapperFactory configMapperFactory,
+            final Class<T> taskClass,
+            final RestClientOutputPluginDelegate<T> delegate) {
+        super(configMapperFactory, taskClass, delegate, delegate, delegate, delegate);
     }
 
     @Override

--- a/src/main/java/org/embulk/base/restclient/RestClientPageOutput.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientPageOutput.java
@@ -21,23 +21,25 @@ import org.embulk.base.restclient.record.RecordExporter;
 import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.SinglePageRecordReader;
 import org.embulk.config.TaskReport;
-import org.embulk.spi.Exec;
 import org.embulk.spi.Page;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
+import org.embulk.util.config.ConfigMapperFactory;
 
 /**
  * RestClientPageOutput is a default |PageOutput| used by |RestClientOutputPluginBase|.
  */
 public class RestClientPageOutput<T extends RestClientOutputTaskBase> implements TransactionalPageOutput {
     public RestClientPageOutput(
+            final ConfigMapperFactory configMapperFactory,
             final Class<T> taskClass,
             final T task,
             final RecordExporter recordExporter,
             final RecordBuffer recordBuffer,
             final Schema embulkSchema,
             final int taskIndex) {
+        this.configMapperFactory = configMapperFactory;
         this.taskClass = taskClass;
         this.task = task;
         this.recordExporter = recordExporter;
@@ -74,9 +76,10 @@ public class RestClientPageOutput<T extends RestClientOutputTaskBase> implements
 
     @Override
     public TaskReport commit() {
-        return this.recordBuffer.commitWithTaskReportUpdated(Exec.newTaskReport());
+        return this.recordBuffer.commitWithTaskReportUpdated(this.configMapperFactory.newTaskReport());
     }
 
+    private final ConfigMapperFactory configMapperFactory;
     private final Class<T> taskClass;
     private final T task;
     private final RecordExporter recordExporter;

--- a/src/main/java/org/embulk/base/restclient/RestClientPluginBase.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientPluginBase.java
@@ -16,15 +16,44 @@
 
 package org.embulk.base.restclient;
 
+import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
+import org.embulk.util.config.ConfigMapperFactory;
 
 public abstract class RestClientPluginBase<T extends RestClientTaskBase> {
+    public RestClientPluginBase(final ConfigMapperFactory configMapperFactory) {
+        this.configMapperFactory = configMapperFactory;
+    }
+
+    protected final ConfigMapperFactory getConfigMapperFactory() {
+        return this.configMapperFactory;
+    }
+
     protected final T loadConfig(final ConfigSource config, final Class<T> taskClass) {
-        return config.loadConfig(taskClass);
+        return this.configMapperFactory.createConfigMapper().map(config, taskClass);
     }
 
     protected final T loadTask(final TaskSource taskSource, final Class<T> taskClass) {
-        return taskSource.loadTask(taskClass);
+        return this.configMapperFactory.createTaskMapper().map(taskSource, taskClass);
     }
+
+    protected final ConfigDiff newConfigDiff() {
+        return this.configMapperFactory.newConfigDiff();
+    }
+
+    protected final ConfigSource newConfigSource() {
+        return this.configMapperFactory.newConfigSource();
+    }
+
+    protected final TaskReport newTaskReport() {
+        return this.configMapperFactory.newTaskReport();
+    }
+
+    protected final TaskSource newTaskSource() {
+        return this.configMapperFactory.newTaskSource();
+    }
+
+    private final ConfigMapperFactory configMapperFactory;
 }

--- a/src/main/java/org/embulk/base/restclient/RestClientTaskBase.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientTaskBase.java
@@ -16,7 +16,7 @@
 
 package org.embulk.base.restclient;
 
-import org.embulk.config.Task;
+import org.embulk.util.config.Task;
 
 public interface RestClientTaskBase extends Task {
 }

--- a/src/test/java/org/embulk/base/restclient/NoNullsOutputTestPlugin.java
+++ b/src/test/java/org/embulk/base/restclient/NoNullsOutputTestPlugin.java
@@ -16,8 +16,12 @@
 
 package org.embulk.base.restclient;
 
+import org.embulk.util.config.ConfigMapperFactory;
+
 class NoNullsOutputTestPlugin extends RestClientOutputPluginBase<OutputTestPluginDelegate.PluginTask> {
-    NoNullsOutputTestPlugin() {
-        super(OutputTestPluginDelegate.PluginTask.class, new OutputTestPluginDelegate(false));
+    NoNullsOutputTestPlugin(final ConfigMapperFactory configMapperFactory) {
+        super(configMapperFactory,
+              OutputTestPluginDelegate.PluginTask.class,
+              new OutputTestPluginDelegate(false, configMapperFactory));
     }
 }

--- a/src/test/java/org/embulk/base/restclient/NoNullsRestClientPageOutputTest.java
+++ b/src/test/java/org/embulk/base/restclient/NoNullsRestClientPageOutputTest.java
@@ -27,13 +27,13 @@ import org.embulk.base.restclient.OutputTestPluginDelegate.PluginTask;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
-import org.embulk.spi.Exec;
 import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.Page;
 import org.embulk.spi.PageTestUtils;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
 import org.embulk.spi.time.Timestamp;
+import org.embulk.util.config.ConfigMapperFactory;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -49,14 +49,17 @@ public class NoNullsRestClientPageOutputTest {
 
     private OutputTestUtils utils;
     private NoNullsOutputTestPlugin plugin;
+    private ConfigMapperFactory configMapperFactory;
 
     @Before
     public void createResources() throws Exception {
-        utils = new OutputTestUtils();
-        utils.initializeConstant();
-        // PluginTask task = utils.configJson().loadConfig(PluginTask.class);
+        configMapperFactory = ConfigMapperFactory.builder().addDefaultModules().build();
 
-        plugin = new NoNullsOutputTestPlugin();
+        utils = new OutputTestUtils(configMapperFactory);
+        utils.initializeConstant();
+        // PluginTask task = configMapperFactory.createConfigMapper().map(utils.configJson(), PluginTask.class);
+
+        plugin = new NoNullsOutputTestPlugin(configMapperFactory);
     }
 
     @Test
@@ -67,16 +70,16 @@ public class NoNullsRestClientPageOutputTest {
     public void testOutputWithNullValues() throws Exception {
         final ConfigSource config = this.utils.configJson();
         final Schema schema = this.utils.jsonSchema();
-        final PluginTask task = config.loadConfig(PluginTask.class);
+        final PluginTask task = configMapperFactory.createConfigMapper().map(config, PluginTask.class);
         this.plugin.transaction(config, schema, 0, new OutputPlugin.Control() {
                 @Override
                 public List<TaskReport> run(final TaskSource taskSource) {
                     final ArrayList<TaskReport> newList = new ArrayList<>();
-                    newList.add(Exec.newTaskReport());
+                    newList.add(configMapperFactory.newTaskReport());
                     return newList;
                 }
             });
-        final TransactionalPageOutput output = this.plugin.open(task.dump(), schema, 0);
+        final TransactionalPageOutput output = this.plugin.open(task.toTaskSource(), schema, 0);
 
         // id, long, timestamp, boolean, double, string
         final List<Page> pages =
@@ -100,16 +103,16 @@ public class NoNullsRestClientPageOutputTest {
     public void testOutputWithRegularValues() throws Exception {
         final ConfigSource config = this.utils.configJson();
         final Schema schema = this.utils.jsonSchema();
-        final PluginTask task = config.loadConfig(PluginTask.class);
+        final PluginTask task = configMapperFactory.createConfigMapper().map(config, PluginTask.class);
         this.plugin.transaction(config, schema, 0, new OutputPlugin.Control() {
                 @Override
                 public List<TaskReport> run(final TaskSource taskSource) {
                     final ArrayList<TaskReport> newList = new ArrayList<>();
-                    newList.add(Exec.newTaskReport());
+                    newList.add(configMapperFactory.newTaskReport());
                     return newList;
                 }
             });
-        final TransactionalPageOutput output = this.plugin.open(task.dump(), schema, 0);
+        final TransactionalPageOutput output = this.plugin.open(task.toTaskSource(), schema, 0);
 
         // id, long, timestamp, boolean, double, string
         final List<Page> pages = PageTestUtils.buildPage(

--- a/src/test/java/org/embulk/base/restclient/OutputTestPlugin.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestPlugin.java
@@ -16,8 +16,12 @@
 
 package org.embulk.base.restclient;
 
+import org.embulk.util.config.ConfigMapperFactory;
+
 class OutputTestPlugin extends RestClientOutputPluginBase<OutputTestPluginDelegate.PluginTask> {
-    OutputTestPlugin() {
-        super(OutputTestPluginDelegate.PluginTask.class, new OutputTestPluginDelegate(true));
+    OutputTestPlugin(final ConfigMapperFactory configMapperFactory) {
+        super(configMapperFactory,
+              OutputTestPluginDelegate.PluginTask.class,
+              new OutputTestPluginDelegate(true, configMapperFactory));
     }
 }

--- a/src/test/java/org/embulk/base/restclient/OutputTestPluginDelegate.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestPluginDelegate.java
@@ -24,14 +24,15 @@ import org.embulk.base.restclient.jackson.scope.JacksonAllInObjectScope;
 import org.embulk.base.restclient.record.RecordBuffer;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.TaskReport;
-import org.embulk.spi.Exec;
 import org.embulk.spi.Schema;
+import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.timestamp.TimestampFormatter;
 
 public class OutputTestPluginDelegate implements RestClientOutputPluginDelegate<OutputTestPluginDelegate.PluginTask> {
-    OutputTestPluginDelegate(final boolean outputNulls) {
+    OutputTestPluginDelegate(final boolean outputNulls, final ConfigMapperFactory configMapperFactory) {
         buffers = new ArrayList<>();
         this.outputNulls = outputNulls;
+        this.configMapperFactory = configMapperFactory;
     }
 
     public interface PluginTask extends RestClientOutputTaskBase {
@@ -53,7 +54,7 @@ public class OutputTestPluginDelegate implements RestClientOutputPluginDelegate<
 
     @Override  // Overridden from |RecordBufferBuildable|
     public RecordBuffer buildRecordBuffer(final PluginTask task, final Schema schema, final int taskIndex) {
-        final OutputTestRecordBuffer buffer = new OutputTestRecordBuffer("records", task);
+        final OutputTestRecordBuffer buffer = new OutputTestRecordBuffer("records", task, this.configMapperFactory);
         OutputTestPluginDelegate.buffers.add(buffer);
         return buffer;
     }
@@ -64,7 +65,7 @@ public class OutputTestPluginDelegate implements RestClientOutputPluginDelegate<
             final Schema schema,
             final int taskIndex,
             final List<TaskReport> taskReports) {
-        return Exec.newConfigDiff();
+        return this.configMapperFactory.newConfigDiff();
     }
 
     static ArrayList<OutputTestRecordBuffer> getBuffers() {
@@ -74,4 +75,6 @@ public class OutputTestPluginDelegate implements RestClientOutputPluginDelegate<
     private static ArrayList<OutputTestRecordBuffer> buffers;
 
     private final boolean outputNulls;
+
+    private final ConfigMapperFactory configMapperFactory;
 }

--- a/src/test/java/org/embulk/base/restclient/OutputTestRecordBuffer.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestRecordBuffer.java
@@ -28,16 +28,20 @@ import org.embulk.base.restclient.jackson.JacksonServiceRecord;
 import org.embulk.base.restclient.record.RecordBuffer;
 import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.config.TaskReport;
-import org.embulk.spi.Exec;
+import org.embulk.util.config.ConfigMapperFactory;
 
 public class OutputTestRecordBuffer extends RecordBuffer {
-    OutputTestRecordBuffer(final String attributeName, final OutputTestPluginDelegate.PluginTask task) {
+    OutputTestRecordBuffer(
+            final String attributeName,
+            final OutputTestPluginDelegate.PluginTask task,
+            final ConfigMapperFactory configMapperFactory) {
         this.attributeName = attributeName;
         this.task = task;
         this.mapper = new ObjectMapper()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, false);
         this.records = OBJECT_MAPPER.createArrayNode();
+        this.configMapperFactory = configMapperFactory;
     }
 
     @Override
@@ -67,7 +71,7 @@ public class OutputTestRecordBuffer extends RecordBuffer {
 
     @Override
     public TaskReport commitWithTaskReportUpdated(final TaskReport taskReport) {
-        return Exec.newTaskReport().set("inserted", this.totalCount);
+        return this.configMapperFactory.newTaskReport().set("inserted", this.totalCount);
     }
 
     @Override
@@ -87,4 +91,5 @@ public class OutputTestRecordBuffer extends RecordBuffer {
 
     private ArrayNode records;
     private long totalCount;
+    private final ConfigMapperFactory configMapperFactory;
 }

--- a/src/test/java/org/embulk/base/restclient/OutputTestUtils.java
+++ b/src/test/java/org/embulk/base/restclient/OutputTestUtils.java
@@ -20,18 +20,22 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.embulk.config.ConfigSource;
-import org.embulk.spi.Exec;
 import org.embulk.spi.Schema;
 import org.embulk.spi.type.Types;
+import org.embulk.util.config.ConfigMapperFactory;
 
 class OutputTestUtils {
+    OutputTestUtils(final ConfigMapperFactory configMapperFactory) {
+        this.configMapperFactory = configMapperFactory;
+    }
+
     void initializeConstant() {
         // noinspection ConstantConditions
         JSON_PATH_PREFIX = OutputTestUtils.class.getClassLoader().getResource("sample_01.json").getPath();
     }
 
     ConfigSource configJson() {
-        return Exec.newConfigSource()
+        return this.configMapperFactory.newConfigSource()
                 .set("in", inputConfigJson())
                 .set("parser", parserConfigJson());
     }
@@ -61,4 +65,6 @@ class OutputTestUtils {
     }
 
     private static String JSON_PATH_PREFIX;
+
+    private final ConfigMapperFactory configMapperFactory;
 }

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPlugin.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPlugin.java
@@ -17,9 +17,14 @@
 package org.embulk.input.shopify;
 
 import org.embulk.base.restclient.RestClientInputPluginBase;
+import org.embulk.util.config.ConfigMapperFactory;
 
 public class ShopifyInputPlugin extends RestClientInputPluginBase<ShopifyInputPluginDelegate.PluginTask> {
     public ShopifyInputPlugin() {
-        super(ShopifyInputPluginDelegate.PluginTask.class, new ShopifyInputPluginDelegate());
+        super(CONFIG_MAPPER_FACTORY,
+              ShopifyInputPluginDelegate.PluginTask.class,
+              new ShopifyInputPluginDelegate(CONFIG_MAPPER_FACTORY));
     }
+
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 }

--- a/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
+++ b/src/test/java/org/embulk/input/shopify/ShopifyInputPluginDelegate.java
@@ -33,16 +33,16 @@ import org.embulk.base.restclient.jackson.JacksonServiceRecord;
 import org.embulk.base.restclient.jackson.JacksonServiceResponseMapper;
 import org.embulk.base.restclient.jackson.StringJsonParser;
 import org.embulk.base.restclient.record.RecordImporter;
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
 import org.embulk.config.TaskReport;
 import org.embulk.spi.DataException;
-import org.embulk.spi.Exec;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.Schema;
 import org.embulk.spi.type.Types;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
+import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.retryhelper.jaxrs.JAXRSClientCreator;
 import org.embulk.util.retryhelper.jaxrs.JAXRSRetryHelper;
 import org.embulk.util.retryhelper.jaxrs.JAXRSSingleRequester;
@@ -52,6 +52,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ShopifyInputPluginDelegate implements RestClientInputPluginDelegate<ShopifyInputPluginDelegate.PluginTask> {
+    public ShopifyInputPluginDelegate(final ConfigMapperFactory configMapperFactory) {
+        this.configMapperFactory = configMapperFactory;
+    }
+
     public interface PluginTask extends RestClientInputTaskBase {
         // client retry setting
         @Config("retry_limit")
@@ -139,7 +143,7 @@ public class ShopifyInputPluginDelegate implements RestClientInputPluginDelegate
     public ConfigDiff buildConfigDiff(
             final PluginTask task, final Schema schema, final int taskCount, final List<TaskReport> taskReports) {
         // should implement for incremental data loading
-        return Exec.newConfigDiff();
+        return this.configMapperFactory.newConfigDiff();
     }
 
     @Override  // Overridden from |ServiceDataIngestable|
@@ -186,7 +190,7 @@ public class ShopifyInputPluginDelegate implements RestClientInputPluginDelegate
                 pageIndex++;
             }
         }
-        return Exec.newTaskReport();
+        return this.configMapperFactory.newTaskReport();
     }
 
     @Override  // Overridden from |ServiceDataSplitterBuildable|
@@ -239,4 +243,6 @@ public class ShopifyInputPluginDelegate implements RestClientInputPluginDelegate
     private static final int PAGE_LIMIT = 250;
 
     private final StringJsonParser jsonParser = new StringJsonParser();
+
+    private final ConfigMapperFactory configMapperFactory;
 }

--- a/src/test/java/org/embulk/input/shopify/TestShopifyInputPlugin.java
+++ b/src/test/java/org/embulk/input/shopify/TestShopifyInputPlugin.java
@@ -31,8 +31,8 @@ import org.embulk.config.TaskSource;
 import org.embulk.spi.InputPlugin;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TestPageBuilderReader.MockPageOutput;
+import org.embulk.util.config.ConfigMapperFactory;
 
-import static org.embulk.spi.Exec.newConfigSource;
 import static org.junit.Assume.assumeNotNull;
 
 public class TestShopifyInputPlugin
@@ -98,4 +98,6 @@ public class TestShopifyInputPlugin
                 .set("password", shopifyPassword)
                 .set("store_name", shopifyStoreName);
     }
+
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 }


### PR DESCRIPTION
`embulk-base-restclient:0.10.0` starts using `embulk-util-config` instead of embulk-core's config processor.

It changes method signatures of `embulk-base-restclient`, then method-level compatibility is lost. Plugins using this library need some modifications to catch-up.