### PR TITLE
Use embulk-util-json instead of embulk-core's JsonParser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     // Excluding all transitive dependencies from embulk-api and embulk-core,
     // and declaring necessary dependencies explicitly.
     api "org.embulk:embulk-util-config:0.1.3"
+    api "org.embulk:embulk-util-json:0.1.0"
     api "org.embulk:embulk-util-timestamp:0.2.1"
     api "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     api "com.fasterxml.jackson.core:jackson-core:2.6.7"

--- a/embulk-input-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -9,6 +9,7 @@ javax.annotation:javax.annotation-api:1.2
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1
 org.embulk:embulk-util-config:0.1.3
+org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-retryhelper-jaxrs:0.8.0
 org.embulk:embulk-util-retryhelper:0.8.0
 org.embulk:embulk-util-rubytime:0.3.2

--- a/embulk-input-example_jetty93/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-example_jetty93/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -11,6 +11,7 @@ org.eclipse.jetty:jetty-http:9.3.16.v20170120
 org.eclipse.jetty:jetty-io:9.3.16.v20170120
 org.eclipse.jetty:jetty-util:9.3.16.v20170120
 org.embulk:embulk-util-config:0.1.3
+org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-retryhelper-jetty93:0.8.0
 org.embulk:embulk-util-retryhelper:0.8.0
 org.embulk:embulk-util-rubytime:0.3.2

--- a/embulk-output-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-output-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -9,6 +9,7 @@ javax.annotation:javax.annotation-api:1.2
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1
 org.embulk:embulk-util-config:0.1.3
+org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-retryhelper-jaxrs:0.8.0
 org.embulk:embulk-util-retryhelper:0.8.0
 org.embulk:embulk-util-rubytime:0.3.2

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -8,5 +8,6 @@ org.embulk:embulk-api:0.10.12
 org.embulk:embulk-core:0.10.12
 org.embulk:embulk-spi:0.10.12
 org.embulk:embulk-util-config:0.1.3
+org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -7,6 +7,7 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.1.3
+org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceResponseMapper.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceResponseMapper.java
@@ -32,9 +32,9 @@ import org.embulk.base.restclient.record.values.LongValueImporter;
 import org.embulk.base.restclient.record.values.StringValueImporter;
 import org.embulk.base.restclient.record.values.TimestampValueImporter;
 import org.embulk.spi.Column;
-import org.embulk.spi.json.JsonParser;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
+import org.embulk.util.json.JsonParser;
 import org.embulk.util.timestamp.TimestampFormatter;
 
 /**

--- a/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceValue.java
+++ b/src/main/java/org/embulk/base/restclient/jackson/JacksonServiceValue.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import java.time.Instant;
 import org.embulk.base.restclient.record.ServiceValue;
-import org.embulk.spi.json.JsonParser;
+import org.embulk.util.json.JsonParser;
 import org.embulk.util.timestamp.TimestampFormatter;
 import org.msgpack.value.Value;
 

--- a/src/main/java/org/embulk/base/restclient/record/ServiceValue.java
+++ b/src/main/java/org/embulk/base/restclient/record/ServiceValue.java
@@ -17,7 +17,7 @@
 package org.embulk.base.restclient.record;
 
 import java.time.Instant;
-import org.embulk.spi.json.JsonParser;
+import org.embulk.util.json.JsonParser;
 import org.embulk.util.timestamp.TimestampFormatter;
 import org.msgpack.value.Value;
 

--- a/src/main/java/org/embulk/base/restclient/record/values/JsonValueImporter.java
+++ b/src/main/java/org/embulk/base/restclient/record/values/JsonValueImporter.java
@@ -23,7 +23,7 @@ import org.embulk.base.restclient.record.ValueLocator;
 import org.embulk.spi.Column;
 import org.embulk.spi.DataException;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.json.JsonParser;
+import org.embulk.util.json.JsonParser;
 
 public class JsonValueImporter extends ValueImporter {
     public JsonValueImporter(final Column column, final ValueLocator valueLocator, final JsonParser jsonParser) {


### PR DESCRIPTION
`embulk-base-restclient:0.10.0` starts using `embulk-util-json` instead of embulk-core's `JsonParser`.

It changes one method signature of `embulk-base-restclient`, then method-level compatibility is lost. Plugins using this library need a modification to catch-up.