### PR TITLE
Reduce use of org.embulk.spi.time.Timestamp

### DIFF
--- a/src/main/java/org/embulk/base/restclient/record/SinglePageRecordReader.java
+++ b/src/main/java/org/embulk/base/restclient/record/SinglePageRecordReader.java
@@ -74,10 +74,12 @@ public class SinglePageRecordReader {
         return this.pageReader.getString(columnIndex);
     }
 
+    @SuppressWarnings("deprecation")  // org.embulk.spi.time.Timestamp
     public Instant getTimestamp(final Column column) {
         return this.pageReader.getTimestamp(column).getInstant();
     }
 
+    @SuppressWarnings("deprecation")  // org.embulk.spi.time.Timestamp
     public Instant getTimestamp(final int columnIndex) {
         return this.pageReader.getTimestamp(columnIndex).getInstant();
     }

--- a/src/main/java/org/embulk/base/restclient/record/values/TimestampValueImporter.java
+++ b/src/main/java/org/embulk/base/restclient/record/values/TimestampValueImporter.java
@@ -16,6 +16,7 @@
 
 package org.embulk.base.restclient.record.values;
 
+import java.time.Instant;
 import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ServiceValue;
 import org.embulk.base.restclient.record.ValueImporter;
@@ -23,7 +24,6 @@ import org.embulk.base.restclient.record.ValueLocator;
 import org.embulk.spi.Column;
 import org.embulk.spi.DataException;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.time.Timestamp;
 import org.embulk.util.timestamp.TimestampFormatter;
 
 public class TimestampValueImporter extends ValueImporter {
@@ -40,7 +40,7 @@ public class TimestampValueImporter extends ValueImporter {
             if (value == null || value.isNull()) {
                 pageBuilder.setNull(getColumnToImport());
             } else {
-                pageBuilder.setTimestamp(getColumnToImport(), Timestamp.ofInstant(value.timestampValue(timestampFormatter)));
+                setTimestampToPageBuilder(pageBuilder, getColumnToImport(), value.timestampValue(timestampFormatter));
             }
         } catch (final Exception ex) {
             throw new DataException(
@@ -48,6 +48,11 @@ public class TimestampValueImporter extends ValueImporter {
                     + " (" + getColumnToImport().getType().getName() + ")",
                     ex);
         }
+    }
+
+    @SuppressWarnings("deprecation")  // org.embulk.spi.time.Timestamp
+    private static void setTimestampToPageBuilder(final PageBuilder pageBuilder, final Column column, final Instant instant) {
+        pageBuilder.setTimestamp(column, org.embulk.spi.time.Timestamp.ofInstant(instant));
     }
 
     private final TimestampFormatter timestampFormatter;

--- a/src/test/java/org/embulk/base/restclient/NoNullsRestClientPageOutputTest.java
+++ b/src/test/java/org/embulk/base/restclient/NoNullsRestClientPageOutputTest.java
@@ -32,7 +32,6 @@ import org.embulk.spi.Page;
 import org.embulk.spi.PageTestUtils;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
-import org.embulk.spi.time.Timestamp;
 import org.embulk.util.config.ConfigMapperFactory;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -120,7 +119,7 @@ public class NoNullsRestClientPageOutputTest {
                 schema,
                 2L,
                 42L,
-                Timestamp.ofInstant(Instant.ofEpochSecond(1509738161)),
+                getTimestampFromInstant(Instant.ofEpochSecond(1509738161)),
                 true,
                 123.45,
                 "embulk");
@@ -138,5 +137,10 @@ public class NoNullsRestClientPageOutputTest {
 
         assertThat(res, is(
                 "[{\"id\":2,\"long\":42,\"timestamp\":\"2017-11-03T19:42:41.000+0000\",\"boolean\":true,\"double\":123.45,\"string\":\"embulk\"}]"));
+    }
+
+    @SuppressWarnings("deprecation")  // org.embulk.spi.time.Timestamp
+    private static org.embulk.spi.time.Timestamp getTimestampFromInstant(final Instant instant) {
+        return org.embulk.spi.time.Timestamp.ofInstant(instant);
     }
 }

--- a/src/test/java/org/embulk/base/restclient/RestClientPageOutputTest.java
+++ b/src/test/java/org/embulk/base/restclient/RestClientPageOutputTest.java
@@ -32,7 +32,6 @@ import org.embulk.spi.Page;
 import org.embulk.spi.PageTestUtils;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
-import org.embulk.spi.time.Timestamp;
 import org.embulk.util.config.ConfigMapperFactory;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -121,7 +120,7 @@ public class RestClientPageOutputTest {
                 schema,
                 2L,
                 42L,
-                Timestamp.ofInstant(Instant.ofEpochSecond(1509738161)),
+                getTimestampFromInstant(Instant.ofEpochSecond(1509738161)),
                 true,
                 123.45,
                 "embulk");
@@ -139,5 +138,10 @@ public class RestClientPageOutputTest {
 
         assertThat(res, is(
                 "[{\"id\":2,\"long\":42,\"timestamp\":\"2017-11-03T19:42:41.000+0000\",\"boolean\":true,\"double\":123.45,\"string\":\"embulk\"}]"));
+    }
+
+    @SuppressWarnings("deprecation")  // org.embulk.spi.time.Timestamp
+    private static org.embulk.spi.time.Timestamp getTimestampFromInstant(final Instant instant) {
+        return org.embulk.spi.time.Timestamp.ofInstant(instant);
     }
 }


### PR DESCRIPTION
`org.embulk.spi.time.Timestamp` is deprecated. Using `java.time.Instant` is now recommended.

But, older Embulk v0.9.23 does not have `Instant`-versions of some methods. So, to keep compatibility until Embulk v0.11, it is still using `org.embulk.spi.time.Timestamp` intentionally.