### PR TITLE
Update to Embulk v0.10.18, and not to depend on "embulk-core"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,15 +28,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.embulk:embulk-api:0.10.12") {
-        exclude group: "*"
-    }
-    compileOnly("org.embulk:embulk-spi:0.10.12") {
-        exclude group: "*"
-    }
-    compileOnly("org.embulk:embulk-core:0.10.12") {
-        exclude group: "*"
-    }
+    compileOnly("org.embulk:embulk-api:0.10.18")
+    compileOnly("org.embulk:embulk-spi:0.10.18")
 
     // Excluding all transitive dependencies from embulk-api and embulk-core,
     // and declaring necessary dependencies explicitly.
@@ -46,13 +39,12 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     api "com.fasterxml.jackson.core:jackson-core:2.6.7"
     api "com.fasterxml.jackson.core:jackson-databind:2.6.7"
-    api "org.msgpack:msgpack-core:0.8.11"
 
     testImplementation "junit:junit:4.13"
-    testImplementation "org.embulk:embulk-api:0.10.12"
-    testImplementation "org.embulk:embulk-core:0.10.12"
-    testImplementation "org.embulk:embulk-core:0.10.12:tests"
-    testImplementation "org.embulk:embulk-deps:0.10.12"
+    testImplementation "org.embulk:embulk-api:0.10.18"
+    testImplementation "org.embulk:embulk-core:0.10.18"
+    testImplementation "org.embulk:embulk-core:0.10.18:tests"
+    testImplementation "org.embulk:embulk-deps:0.10.18"
     testImplementation "org.embulk:embulk-util-retryhelper-jaxrs:0.8.0"
 
     // RESTEasy JAX-RS implementation is required only for testing.

--- a/embulk-input-example/build.gradle
+++ b/embulk-input-example/build.gradle
@@ -18,10 +18,12 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-api:0.10.5"
-    compileOnly "org.embulk:embulk-core:0.10.5"
+    compileOnly "org.embulk:embulk-api:0.10.18"
+    compileOnly "org.embulk:embulk-spi:0.10.18"
 
-    compile project(":")
+    compile(project(":")) {
+        exclude group: "org.msgpack", module: "msgpack-core"
+    }
     compile("org.embulk:embulk-util-retryhelper-jaxrs:0.8.0") {
         exclude group: "org.slf4j", module: "slf4j-api"
     }
@@ -29,23 +31,16 @@ dependencies {
         exclude group: "javax.inject", module: "javax.inject"
     }
 
-    testCompile "org.embulk:embulk-api:0.10.5"
-    testCompile "org.embulk:embulk-core:0.10.5"
-    testCompile "org.embulk:embulk-core:0.10.5:tests"
-    testCompile "org.embulk:embulk-deps-buffer:0.10.5"
-    testCompile "org.embulk:embulk-deps-config:0.10.5"
+    testCompile "org.embulk:embulk-api:0.10.18"
+    testCompile "org.embulk:embulk-core:0.10.18"
+    testCompile "org.embulk:embulk-core:0.10.18:tests"
+    testCompile "org.embulk:embulk-deps:0.10.18"
 }
 
 embulkPlugin {
     mainClass = "org.embulk.input.example.ExampleInputPlugin"
     category = "input"
     type = "example"
-    ignoreConflicts = [
-        [ group: "com.fasterxml.jackson.core", module: "jackson-annotations" ],
-        [ group: "com.fasterxml.jackson.core", module: "jackson-core" ],
-        [ group: "com.fasterxml.jackson.core", module: "jackson-databind" ],
-        [ group: "org.msgpack", module: "msgpack-core" ],
-    ]
 }
 
 gem {

--- a/embulk-input-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -24,4 +24,3 @@ org.glassfish.jersey.bundles.repackaged:jersey-guava:2.25.1
 org.glassfish.jersey.core:jersey-client:2.25.1
 org.glassfish.jersey.core:jersey-common:2.25.1
 org.javassist:javassist:3.20.0-GA
-org.msgpack:msgpack-core:0.8.11

--- a/embulk-input-example_jetty93/build.gradle
+++ b/embulk-input-example_jetty93/build.gradle
@@ -18,19 +18,20 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-api:0.10.5"
-    compileOnly "org.embulk:embulk-core:0.10.5"
+    compileOnly "org.embulk:embulk-api:0.10.18"
+    compileOnly "org.embulk:embulk-spi:0.10.18"
 
-    compile project(":")
+    compile(project(":")) {
+        exclude group: "org.msgpack", module: "msgpack-core"
+    }
     compile("org.embulk:embulk-util-retryhelper-jetty93:0.8.0") {
         exclude group: "org.slf4j", module: "slf4j-api"
     }
 
-    testCompile "org.embulk:embulk-api:0.10.5"
-    testCompile "org.embulk:embulk-core:0.10.5"
-    testCompile "org.embulk:embulk-core:0.10.5:tests"
-    testCompile "org.embulk:embulk-deps-buffer:0.10.5"
-    testCompile "org.embulk:embulk-deps-config:0.10.5"
+    testCompile "org.embulk:embulk-api:0.10.18"
+    testCompile "org.embulk:embulk-core:0.10.18"
+    testCompile "org.embulk:embulk-core:0.10.18:tests"
+    testCompile "org.embulk:embulk-deps:0.10.18"
 }
 
 embulkPlugin {

--- a/embulk-input-example_jetty93/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-example_jetty93/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -16,4 +16,3 @@ org.embulk:embulk-util-retryhelper-jetty93:0.8.0
 org.embulk:embulk-util-retryhelper:0.8.0
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1
-org.msgpack:msgpack-core:0.8.11

--- a/embulk-output-example/build.gradle
+++ b/embulk-output-example/build.gradle
@@ -18,10 +18,12 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-api:0.10.5"
-    compileOnly "org.embulk:embulk-core:0.10.5"
+    compileOnly "org.embulk:embulk-api:0.10.18"
+    compileOnly "org.embulk:embulk-spi:0.10.18"
 
-    compile project(":")
+    compile(project(":")) {
+        exclude group: "org.msgpack", module: "msgpack-core"
+    }
     compile("org.embulk:embulk-util-retryhelper-jaxrs:0.8.0") {
         exclude group: "org.slf4j", module: "slf4j-api"
     }
@@ -29,10 +31,9 @@ dependencies {
         exclude group: "javax.inject", module: "javax.inject"
     }
 
-    testCompile "org.embulk:embulk-api:0.10.5"
-    testCompile "org.embulk:embulk-core:0.10.5:tests"
-    testCompile "org.embulk:embulk-deps-buffer:0.10.5"
-    testCompile "org.embulk:embulk-deps-config:0.10.5"
+    testCompile "org.embulk:embulk-api:0.10.18"
+    testCompile "org.embulk:embulk-core:0.10.18:tests"
+    testCompile "org.embulk:embulk-deps:0.10.18"
 }
 
 embulkPlugin {

--- a/embulk-output-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-output-example/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -24,4 +24,3 @@ org.glassfish.jersey.bundles.repackaged:jersey-guava:2.25.1
 org.glassfish.jersey.core:jersey-client:2.25.1
 org.glassfish.jersey.core:jersey-common:2.25.1
 org.javassist:javassist:3.20.0-GA
-org.msgpack:msgpack-core:0.8.11

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,10 +4,10 @@
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
-org.embulk:embulk-api:0.10.12
-org.embulk:embulk-core:0.10.12
-org.embulk:embulk-spi:0.10.12
+org.embulk:embulk-api:0.10.18
+org.embulk:embulk-spi:0.10.18
 org.embulk:embulk-util-config:0.1.3
 org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.12

--- a/src/main/java/org/embulk/base/restclient/RestClientInputPluginBaseUnsafe.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientInputPluginBaseUnsafe.java
@@ -148,8 +148,23 @@ public class RestClientInputPluginBaseUnsafe<T extends RestClientInputTaskBase>
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk-base-restclient/issues/132
     private static PageBuilder getPageBuilder(final BufferAllocator bufferAllocator, final Schema schema, final PageOutput output) {
-        return new PageBuilder(bufferAllocator, schema, output);
+        if (HAS_EXEC_GET_PAGE_BUILDER) {
+            return Exec.getPageBuilder(bufferAllocator, schema, output);
+        } else {
+            return new PageBuilder(bufferAllocator, schema, output);
+        }
     }
+
+    private static boolean hasExecGetPageBuilder() {
+        try {
+            Exec.class.getMethod("getPageBuilder", BufferAllocator.class, Schema.class, PageOutput.class);
+        } catch (final NoSuchMethodException ex) {
+            return false;
+        }
+        return true;
+    }
+
+    private static final boolean HAS_EXEC_GET_PAGE_BUILDER = hasExecGetPageBuilder();
 
     private final Class<T> taskClass;
     private final ConfigDiffBuildable<T> configDiffBuilder;

--- a/src/main/java/org/embulk/base/restclient/RestClientPageOutput.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientPageOutput.java
@@ -21,6 +21,7 @@ import org.embulk.base.restclient.record.RecordExporter;
 import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.SinglePageRecordReader;
 import org.embulk.config.TaskReport;
+import org.embulk.spi.Exec;
 import org.embulk.spi.Page;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
@@ -81,8 +82,23 @@ public class RestClientPageOutput<T extends RestClientOutputTaskBase> implements
 
     @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk-base-restclient/issues/132
     private static PageReader getPageReader(final Schema schema) {
-        return new PageReader(schema);
+        if (HAS_EXEC_GET_PAGE_READER) {
+            return Exec.getPageReader(schema);
+        } else {
+            return new PageReader(schema);
+        }
     }
+
+    private static boolean hasExecGetPageReader() {
+        try {
+            Exec.class.getMethod("getPageReader", Schema.class);
+        } catch (final NoSuchMethodException ex) {
+            return false;
+        }
+        return true;
+    }
+
+    private static final boolean HAS_EXEC_GET_PAGE_READER = hasExecGetPageReader();
 
     private final ConfigMapperFactory configMapperFactory;
     private final Class<T> taskClass;

--- a/src/main/java/org/embulk/base/restclient/RestClientPageOutput.java
+++ b/src/main/java/org/embulk/base/restclient/RestClientPageOutput.java
@@ -50,7 +50,7 @@ public class RestClientPageOutput<T extends RestClientOutputTaskBase> implements
 
     @Override
     public void add(final Page page) {
-        final PageReader pageReader = new PageReader(this.embulkSchema);
+        final PageReader pageReader = getPageReader(this.embulkSchema);
         pageReader.setPage(page);
         while (pageReader.nextRecord()) {
             final SinglePageRecordReader singlePageRecordReader = new SinglePageRecordReader(pageReader);
@@ -77,6 +77,11 @@ public class RestClientPageOutput<T extends RestClientOutputTaskBase> implements
     @Override
     public TaskReport commit() {
         return this.recordBuffer.commitWithTaskReportUpdated(this.configMapperFactory.newTaskReport());
+    }
+
+    @SuppressWarnings("deprecation")  // https://github.com/embulk/embulk-base-restclient/issues/132
+    private static PageReader getPageReader(final Schema schema) {
+        return new PageReader(schema);
     }
 
     private final ConfigMapperFactory configMapperFactory;

--- a/src/main/java/org/embulk/base/restclient/record/SinglePageRecordReader.java
+++ b/src/main/java/org/embulk/base/restclient/record/SinglePageRecordReader.java
@@ -76,12 +76,26 @@ public class SinglePageRecordReader {
 
     @SuppressWarnings("deprecation")  // org.embulk.spi.time.Timestamp
     public Instant getTimestamp(final Column column) {
-        return this.pageReader.getTimestamp(column).getInstant();
+        if (HAS_GET_TIMESTAMP_INSTANT_COLUMN) {
+            return this.pageReader.getTimestampInstant(column);
+        } else if (HAS_GET_TIMESTAMP_COLUMN) {
+            return this.pageReader.getTimestamp(column).getInstant();
+        } else {
+            throw new IllegalStateException(
+                    "Neither PageReader#getTimestamp(Column) nor PageReader#getTimestampInstant(Column) found.");
+        }
     }
 
     @SuppressWarnings("deprecation")  // org.embulk.spi.time.Timestamp
     public Instant getTimestamp(final int columnIndex) {
-        return this.pageReader.getTimestamp(columnIndex).getInstant();
+        if (HAS_GET_TIMESTAMP_INSTANT_INT) {
+            return this.pageReader.getTimestampInstant(columnIndex);
+        } else if (HAS_GET_TIMESTAMP_INT) {
+            return this.pageReader.getTimestamp(columnIndex).getInstant();
+        } else {
+            throw new IllegalStateException(
+                    "Neither PageReader#getTimestamp(int) nor PageReader#getTimestampInstant(int) found.");
+        }
     }
 
     public Value getJson(final Column column) {
@@ -91,6 +105,50 @@ public class SinglePageRecordReader {
     public Value getJson(final int columnIndex) {
         return this.pageReader.getJson(columnIndex);
     }
+
+    private static boolean hasGetTimestampColumn() {
+        try {
+            PageReader.class.getMethod("getTimestamp", Column.class);
+        } catch (final NoSuchMethodException ex) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean hasGetTimestampInt() {
+        try {
+            PageReader.class.getMethod("getTimestamp", int.class);
+        } catch (final NoSuchMethodException ex) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean hasGetTimestampInstantColumn() {
+        try {
+            PageReader.class.getMethod("getTimestampInstant", Column.class);
+        } catch (final NoSuchMethodException ex) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean hasGetTimestampInstantInt() {
+        try {
+            PageReader.class.getMethod("getTimestampInstant", int.class);
+        } catch (final NoSuchMethodException ex) {
+            return false;
+        }
+        return true;
+    }
+
+    private static final boolean HAS_GET_TIMESTAMP_COLUMN = hasGetTimestampColumn();
+
+    private static final boolean HAS_GET_TIMESTAMP_INT = hasGetTimestampInt();
+
+    private static final boolean HAS_GET_TIMESTAMP_INSTANT_COLUMN = hasGetTimestampInstantColumn();
+
+    private static final boolean HAS_GET_TIMESTAMP_INSTANT_INT = hasGetTimestampInstantInt();
 
     private final PageReader pageReader;
 }


### PR DESCRIPTION
Update depending Embulk to v0.10.18, which is ready for `embulk-core`-less building Embulk plugins.

At the same time, `new PageBuilder` and `new PageReader` are deprecated, but older Embulk v0.9.23 does not have their replacement (`Exec.getPageBuilder` and `Exec.getPageReader`) yet. So, it intentionally keeps using the deprecated constructors.

Similar for `PageBuilder#setTimestamp` and `PageReader#getTimestamp`.

This pull-req has mechanisms to switch automatically between old methods and new methods.