### PR TITLE
Release to Maven Central instead of Bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,15 @@
 plugins {
-    id "com.jfrog.bintray" version "1.8.4"
     id "java"
     id "java-library"
     id "maven-publish"
+    id "signing"
     id "checkstyle"
     id "org.embulk.embulk-plugins" version "0.4.2" apply false
 }
 
 group = "org.embulk"
 version = "0.10.0-SNAPSHOT"
-description = "Base class library to access RESTful services"
+description = "Alternative base classes for Embulk plugins to access RESTful services"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -22,17 +22,13 @@ configurations {
 repositories {
     mavenCentral()
     jcenter()
-    maven {
-        url "https://dl.bintray.com/embulk-base-restclient/maven"
-    }
 }
 
 dependencies {
     compileOnly("org.embulk:embulk-api:0.10.18")
     compileOnly("org.embulk:embulk-spi:0.10.18")
 
-    // Excluding all transitive dependencies from embulk-api and embulk-core,
-    // and declaring necessary dependencies explicitly.
+    // They are "api" dependencies because they are used in method signatures of embulk-base-restclient.
     api "org.embulk:embulk-util-config:0.1.3"
     api "org.embulk:embulk-util-json:0.1.0"
     api "org.embulk:embulk-util-timestamp:0.2.1"
@@ -162,30 +158,24 @@ publishing {
             }
         }
     }
-}
 
-bintray {
-    // write at your bintray user name and api key to ~/.gradle/gradle.properties file:
-    user = project.hasProperty('bintray_user') ? bintray_user : ''
-    key = project.hasProperty('bintray_api_key') ? bintray_api_key : ''
+    repositories {
+        maven {  // publishMavenPublicationToMavenCentralRepository
+            name = "mavenCentral"
+            if (project.version.endsWith("-SNAPSHOT")) {
+                url "https://oss.sonatype.org/content/repositories/snapshots"
+            } else {
+                url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            }
 
-    publications = [ "maven" ]
-    publish = true
-
-    pkg {
-        userOrg = 'embulk-base-restclient'
-        repo = 'maven'
-        name = project.name
-        desc = "${project.description}"
-        websiteUrl = 'https://github.com/embulk/embulk-base-restclient'
-        issueTrackerUrl = 'https://github.com/embulk/embulk-base-restclient/issues'
-        vcsUrl = 'https://github.com/embulk/embulk-base-restclient.git'
-        licenses = ['Apache-2.0']
-        labels = ['embulk', 'java']
-        publicDownloadNumbers = true
-
-        version {
-            name = project.version
+            credentials {
+                username = project.hasProperty("ossrhUsername") ? ossrhUsername : ""
+                password = project.hasProperty("ossrhPassword") ? ossrhPassword : ""
+            }
         }
     }
+}
+
+signing {
+    sign publishing.publications.maven
 }

--- a/embulk-input-example/build.gradle
+++ b/embulk-input-example/build.gradle
@@ -12,9 +12,6 @@ targetCompatibility = 1.8
 repositories {
     mavenCentral()
     jcenter()
-    maven {
-        url "https://dl.bintray.com/embulk-base-restclient/maven"
-    }
 }
 
 dependencies {

--- a/embulk-input-example_jetty93/build.gradle
+++ b/embulk-input-example_jetty93/build.gradle
@@ -12,9 +12,6 @@ targetCompatibility = 1.8
 repositories {
     mavenCentral()
     jcenter()
-    maven {
-        url "https://dl.bintray.com/embulk-base-restclient/maven"
-    }
 }
 
 dependencies {

--- a/embulk-output-example/build.gradle
+++ b/embulk-output-example/build.gradle
@@ -12,9 +12,6 @@ targetCompatibility = 1.8
 repositories {
     mavenCentral()
     jcenter()
-    maven {
-        url "https://dl.bintray.com/embulk-base-restclient/maven"
-    }
 }
 
 dependencies {


### PR DESCRIPTION
All its dependencies are now from Maven Central, then everything can be enclosed in Maven Central. It no longer needs to stay with Bintray.